### PR TITLE
Fix OpenPDF imports in Main class

### DIFF
--- a/src/main/java/com/rochias/prestamgr/Main.java
+++ b/src/main/java/com/rochias/prestamgr/Main.java
@@ -23,8 +23,8 @@ import java.util.function.UnaryOperator;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import com.github.librepdf.openpdf.text.*;
-import com.github.librepdf.openpdf.text.pdf.PdfWriter;
+import com.lowagie.text.*;
+import com.lowagie.text.pdf.PdfWriter;
 import jakarta.mail.*;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;


### PR DESCRIPTION
## Summary
- correct OpenPDF package imports to use `com.lowagie.text` classes

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864483f2828832eb68af7050792d2b1