### PR TITLE
Fix import ambiguity for List

### DIFF
--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -23,7 +23,10 @@ import java.util.function.UnaryOperator;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import com.lowagie.text.*;
+import com.lowagie.text.Document;
+import com.lowagie.text.DocumentException;
+import com.lowagie.text.FontFactory;
+import com.lowagie.text.Paragraph;
 import com.lowagie.text.pdf.PdfWriter;
 import jakarta.mail.*;
 import jakarta.mail.internet.InternetAddress;


### PR DESCRIPTION
## Summary
- avoid wildcard import from OpenPDF
- explicitly import only Document, DocumentException, FontFactory, and Paragraph

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68656a00f828832ea601a11e54688d48