### PR TITLE
Fix PDF export callbacks

### DIFF
--- a/src/main/java/org/example/gui/MainView.java
+++ b/src/main/java/org/example/gui/MainView.java
@@ -166,9 +166,9 @@ public class MainView {
                 Path f = Optional.ofNullable(fc.showSaveDialog(stage)).map(java.io.File::toPath).orElse(null);
                 if (f != null) {
                     runAsync(() -> {
-                        PDF.generateFiche(f, p);
-                        return null;
-                    }, () -> new Alert(Alert.AlertType.INFORMATION, "Fiche PDF exportée", ButtonType.OK).showAndWait());
+                    PDF.generateFiche(f, p);
+                    return null;
+                    }, v -> new Alert(Alert.AlertType.INFORMATION, "Fiche PDF exportée", ButtonType.OK).showAndWait());
                 }
             }
         });
@@ -181,7 +181,7 @@ public class MainView {
                 runAsync(() -> {
                     PDF.generateHistorique(f, dao);
                     return null;
-                }, () -> new Alert(Alert.AlertType.INFORMATION, "Historique PDF exporté", ButtonType.OK).showAndWait());
+                }, v -> new Alert(Alert.AlertType.INFORMATION, "Historique PDF exporté", ButtonType.OK).showAndWait());
             }
         });
 


### PR DESCRIPTION
## Summary
- fix compile errors in `MainView` by using `Consumer` signatures for callbacks

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865916b9b48832e9a3a5cdc498e32f1