### PR TITLE
Use ISO date format in database

### DIFF
--- a/src/main/java/org/example/dao/DB.java
+++ b/src/main/java/org/example/dao/DB.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 public class DB {
     private static final DateTimeFormatter DATE_FR = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+    private static final DateTimeFormatter DATE_DB = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     private final Connection conn;
 
     public DB(String path) {
@@ -113,7 +114,7 @@ public class DB {
         try (PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setInt(1, pid);
             ps.setString(2, desc);
-            ps.setString(3, DATE_FR.format(LocalDate.now()));
+            ps.setString(3, DATE_DB.format(LocalDate.now()));
             ps.executeUpdate();
         } catch (SQLException e) {
             throw new RuntimeException(e);
@@ -126,7 +127,11 @@ public class DB {
             ps.setInt(1, pid);
             ResultSet rs = ps.executeQuery();
             List<ServiceRow> out = new ArrayList<>();
-            while (rs.next()) out.add(new ServiceRow(rs.getString("description"), rs.getString("date")));
+            while (rs.next()) {
+                String raw = rs.getString("date");
+                String date = DATE_FR.format(LocalDate.parse(raw, DATE_DB));
+                out.add(new ServiceRow(rs.getString("description"), date));
+            }
             return out;
         } catch (SQLException e) {
             throw new RuntimeException(e);
@@ -134,6 +139,10 @@ public class DB {
     }
 
     private static Prestataire rowToPrestataire(ResultSet rs) throws SQLException {
+        String raw = rs.getString("date_contrat");
+        String date = raw == null || raw.isBlank()
+                ? ""
+                : DATE_FR.format(LocalDate.parse(raw, DATE_DB));
         return new Prestataire(
                 rs.getInt("id"),
                 rs.getString("nom"),
@@ -142,7 +151,7 @@ public class DB {
                 rs.getString("email"),
                 rs.getInt("note"),
                 rs.getString("facturation"),
-                rs.getString("date_contrat"));
+                date);
     }
 
     private static void fill(PreparedStatement ps, Prestataire p) throws SQLException {
@@ -152,6 +161,6 @@ public class DB {
         ps.setString(4, p.getEmail());
         ps.setInt(5, p.getNote());
         ps.setString(6, p.getFacturation());
-        ps.setString(7, p.getDateContrat());
+        ps.setString(7, LocalDate.parse(p.getDateContrat(), DATE_FR).format(DATE_DB));
     }
 }


### PR DESCRIPTION
## Summary
- store and retrieve ISO formatted dates from DB
- convert dates to `dd/MM/yyyy` when shown in the UI

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b1efce48832e91d129f0c5b6c3a1