### PR TITLE
Add DB tests with JUnit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,8 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <javafx.version>21.0.2</javafx.version>
+        <junit.jupiter.version>5.10.1</junit.jupiter.version>
+        <surefire.plugin.version>3.2.2</surefire.plugin.version>
         <javafx.maven.plugin.version>0.0.8</javafx.maven.plugin.version>
     </properties>
 
@@ -62,6 +64,13 @@
             <version>2.0.1</version>
             <!-- corrigé depuis 2.0.3 (inexistant) -->
         </dependency>
+        <!-- JUnit 5 for tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <!-- Pour exécuter facilement : mvn javafx:run -->
@@ -74,6 +83,11 @@
                 <configuration>
                     <mainClass>org.example.MainApp</mainClass>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.plugin.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/src/test/java/org/example/dao/DBTest.java
+++ b/src/test/java/org/example/dao/DBTest.java
@@ -1,0 +1,60 @@
+package org.example.dao;
+
+import org.example.model.Prestataire;
+import org.example.model.ServiceRow;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DBTest {
+    private static final DateTimeFormatter DATE_FR = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+    private DB db;
+
+    @BeforeEach
+    void setUp() {
+        db = new DB(":memory:");
+    }
+
+    @AfterEach
+    void tearDown() {
+        db.close();
+    }
+
+    private Prestataire createSample() {
+        String date = LocalDate.now().format(DATE_FR);
+        return new Prestataire(0, "Nom", "Societe", "0123456789", "a@b.com", 60, "Fact", date);
+    }
+
+    @Test
+    void testCRUD() {
+        Prestataire p = createSample();
+        db.add(p);
+
+        List<Prestataire> all = db.list("");
+        assertEquals(1, all.size());
+        Prestataire stored = all.get(0);
+        assertEquals(p.getNom(), stored.getNom());
+        int id = stored.getId();
+
+        stored.setNom("Updated");
+        db.update(stored);
+
+        all = db.list("");
+        assertEquals("Updated", all.get(0).getNom());
+
+        db.addService(id, "Service");
+        List<ServiceRow> services = db.services(id);
+        assertEquals(1, services.size());
+        assertEquals("Service", services.get(0).desc());
+
+        db.delete(id);
+        assertTrue(db.list("").isEmpty());
+        assertTrue(db.services(id).isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit and surefire plugin configuration
- create `DBTest` using an in-memory SQLite DB

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b43b117c832e8beffed171aced1a