### PR TITLE
Add invoice status indicators with CSS classes

### DIFF
--- a/src/main/java/org/example/gui/MainView.java
+++ b/src/main/java/org/example/gui/MainView.java
@@ -7,6 +7,7 @@ import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.*;
 import javafx.scene.control.cell.PropertyValueFactory;
+import javafx.beans.property.ReadOnlyBooleanWrapper;
 import javafx.scene.layout.*;
 import javafx.stage.FileChooser;
 import javafx.stage.Modality;
@@ -100,6 +101,25 @@ public class MainView {
             c.setCellValueFactory(new PropertyValueFactory<>(props[i]));
             table.getColumns().add(c);
         }
+
+        TableColumn<Prestataire, Boolean> cOk = new TableColumn<>("Toutes factures payées");
+        cOk.setCellValueFactory(data ->
+                new ReadOnlyBooleanWrapper(dao.factures(data.getValue().getId(), false).isEmpty()));
+
+        cOk.setCellFactory(col -> new TableCell<>() {
+            @Override protected void updateItem(Boolean val, boolean empty) {
+                super.updateItem(val, empty);
+                if (empty || val == null) {
+                    setText(null);
+                    getStyleClass().removeAll("cell-paid","cell-unpaid");
+                } else {
+                    setText(val ? "\u2714" : "\u2717");
+                    getStyleClass().removeAll("cell-paid","cell-unpaid");
+                    getStyleClass().add(val ? "cell-paid" : "cell-unpaid");
+                }
+            }
+        });
+        table.getColumns().add(cOk);
         table.getSelectionModel().selectedItemProperty().addListener((obs, o, n) -> updateDetails(n));
         table.setPrefWidth(580);
     }
@@ -310,11 +330,28 @@ public class MainView {
         /* ====== TableView ====== */
         TableView<Facture> tv = new TableView<>();
         tv.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        TableColumn<Facture, Boolean> cPaye = new TableColumn<>("Réglée");
+        cPaye.setCellValueFactory(new PropertyValueFactory<>("paye"));
+
+        cPaye.setCellFactory(col -> new TableCell<>() {
+            @Override protected void updateItem(Boolean val, boolean empty) {
+                super.updateItem(val, empty);
+                if (empty || val == null) {
+                    setText(null);
+                    getStyleClass().removeAll("cell-paid","cell-unpaid");
+                } else {
+                    setText(val ? "\u2714" /*✓*/ : "\u2717" /*✗*/);
+                    getStyleClass().removeAll("cell-paid","cell-unpaid");
+                    getStyleClass().add(val ? "cell-paid" : "cell-unpaid");
+                }
+            }
+        });
+
         tv.getColumns().addAll(
             col("Échéance","echeanceFr"),
             col("Description","description"),
             col("Montant","montant"),
-            col("Réglée","paye"),
+            cPaye,
             col("Date paiement","datePaiementFr")
         );
         tv.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);

--- a/src/main/resources/css/dark.css
+++ b/src/main/resources/css/dark.css
@@ -1,0 +1,6 @@
+/* Application dark theme */
+
+
+/* --- états payé / impayé ----------------------------------------- */
+.cell-paid   { -fx-text-fill: #10a37f; }   /* vert ChatGPT */
+.cell-unpaid { -fx-text-fill: #e74c3c; }   /* rouge */


### PR DESCRIPTION
## Summary
- apply boolean cell styling for invoices and provider payment status
- add dark theme stylesheet with paid/unpaid classes

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866e7d10464832eb62cf66262d64e4e