### PR TITLE
Add ChatGPT dark theme

### DIFF
--- a/src/main/java/org/example/MainApp.java
+++ b/src/main/java/org/example/MainApp.java
@@ -20,7 +20,9 @@ public class MainApp extends Application {
         dao = new DB(DB_FILE);
         view = new MainView(primaryStage, dao);
         primaryStage.setTitle("Gestion des Prestataires");
-        primaryStage.setScene(new Scene(view.getRoot(), 920, 600));
+        Scene sc = new Scene(view.getRoot(), 920, 600);
+        sc.getStylesheets().add(getClass().getResource("/css/dark.css").toExternalForm());
+        primaryStage.setScene(sc);
         primaryStage.show();
     }
 

--- a/src/main/resources/css/dark.css
+++ b/src/main/resources/css/dark.css
@@ -1,5 +1,33 @@
 /* Application dark theme */
 
+/* Palette inspirée de chat.openai.com */
+.root {
+    -fx-base: #202123;
+    -fx-background: #202123;
+    -fx-control-inner-background: #2b2c2f;
+    -fx-accent: #10a37f;
+    -fx-focus-color: #10a37f;
+    -fx-faint-focus-color: transparent;
+    -fx-text-fill: #e6e6e6;
+}
+
+.label { -fx-text-fill: #e6e6e6; }
+.table-view, .list-view {
+    -fx-background-color: #2b2c2f;
+    -fx-table-cell-border-color: #3e3f42;
+}
+.table-row-cell:filled:selected, .list-cell:filled:selected {
+    -fx-background-color: #3e4a54;
+}
+
+.button {
+    -fx-background-radius: 4;
+    -fx-background-color: #3e3f42;
+    -fx-text-fill: #e6e6e6;
+}
+.button:hover {
+    -fx-background-color: #4f5054;
+}
 
 /* --- états payé / impayé ----------------------------------------- */
 .cell-paid   { -fx-text-fill: #10a37f; }   /* vert ChatGPT */


### PR DESCRIPTION
## Summary
- implement a dark color palette
- apply stylesheet in `MainApp`

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866ed853c10832eb15b8faa2248e011