### PR TITLE
Add styled titles to popup dialogs

### DIFF
--- a/src/main/java/org/example/gui/MainView.java
+++ b/src/main/java/org/example/gui/MainView.java
@@ -314,7 +314,11 @@ public class MainView {
         }
         Stage win = new Stage();
         win.setTitle("Historique — " + p.getNom());
-        VBox vb = new VBox(6);
+
+        Label title = new Label("Historique — " + p.getNom());
+        title.getStyleClass().add("title");
+
+        VBox vb = new VBox(6, title);
         vb.setPadding(new Insets(10));
         vb.getChildren().add(new Label("Chargement..."));
         Scene sc = new Scene(new ScrollPane(vb), 400, 400);
@@ -323,7 +327,7 @@ public class MainView {
         win.initModality(Modality.WINDOW_MODAL);
         win.show();
         runAsync(() -> dao.services(p.getId()), list -> {
-            vb.getChildren().clear();
+            vb.getChildren().setAll(title);
             list.forEach(sr -> vb.getChildren().add(new Label(sr.date() + " — " + sr.desc())));
         });
     }
@@ -334,6 +338,9 @@ public class MainView {
 
         Stage win = new Stage();
         win.setTitle("Factures — "+p.getNom());
+
+        Label title = new Label("Factures — "+p.getNom());
+        title.getStyleClass().add("title");
 
         /* ====== TableView ====== */
         TableView<Facture> tv = new TableView<>();
@@ -393,7 +400,7 @@ public class MainView {
         HBox buttons = new HBox(10,bAdd,bToggle,bClose);
         buttons.setPadding(new Insets(10));
 
-        VBox root = new VBox(10, tv, buttons);
+        VBox root = new VBox(10, title, tv, buttons);
         root.setPadding(new Insets(10));
         Scene sc = new Scene(root, 600, 400);
         sc.getStylesheets().add(getClass().getResource("/css/dark.css").toExternalForm());


### PR DESCRIPTION
## Summary
- display a visible title label for history window
- display a visible title label for invoices window
- keep stage titles while styling the new labels

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f6fb37a4832e8847466947f7418b