### PR TITLE
Add Rappel model and DAO operations

### DIFF
--- a/src/main/java/org/example/model/Rappel.java
+++ b/src/main/java/org/example/model/Rappel.java
@@ -1,0 +1,6 @@
+package org.example.model;
+
+import java.time.LocalDateTime;
+
+public record Rappel(int id, int factureId, String dest, String sujet,
+                     String corps, LocalDateTime dateEnvoi, boolean envoye) {}


### PR DESCRIPTION
## Summary
- introduce `rappels` table creation in DB constructor
- add `Rappel` record model
- implement DAO helpers for creating and sending reminders

## Testing
- `mvn -q test` *(fails: command not found)*
- `javac --release 17 @sources.txt` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68685486ab64832e8c6d13c66726e0c5