### PR TITLE
Add security notes for email

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,17 @@ mvn package
 ```
 
 The resulting archive will be located under `target/`.
+
+## Security & environment
+
+To send e‑mails via Gmail you must enable “App passwords” on your account (or
+use the SMTP server provided by your host). Once enabled, export the following
+environment variables before running the program so that `Mailer.send()` can use
+TLS on port 465:
+
+```bash
+export MAIL_USER="your.address@gmail.com"
+export MAIL_PWD="the_application_password"
+```
+
+With these variables in place the mailer should work out of the box.


### PR DESCRIPTION
## Summary
- update README with instructions for Gmail app passwords and TLS port 465

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68685709bb6c832eaddb9959fb96a70a