### PR TITLE
Add MailPrefs DAO with tests

### DIFF
--- a/src/main/java/org/example/dao/MailPrefsDAO.java
+++ b/src/main/java/org/example/dao/MailPrefsDAO.java
@@ -1,0 +1,34 @@
+package org.example.dao;
+
+import org.example.mail.MailPrefs;
+
+import java.sql.*;
+
+public class MailPrefsDAO {
+    private final Connection c;
+    public MailPrefsDAO(Connection c){ this.c = c; }
+
+    public MailPrefs load(){
+        try (Statement st = c.createStatement()){
+            ResultSet rs = st.executeQuery("SELECT * FROM mail_prefs WHERE id=1");
+            if(!rs.next()) return MailPrefs.defaultValues();
+            return MailPrefs.fromRS(rs);
+        } catch(SQLException e){ throw new RuntimeException(e);}    }
+    public void save(MailPrefs p){
+        String sql = """
+            INSERT INTO mail_prefs(id,host,port,ssl,user,pwd,from_addr,copy_to_self,
+                                   delay_hours,subj_tpl_presta,body_tpl_presta,
+                                   subj_tpl_self,body_tpl_self)
+            VALUES(1,?,?,?,?,?,?,?,?,?,?,?,?)
+            ON CONFLICT(id) DO UPDATE SET
+              host=excluded.host,port=excluded.port,ssl=excluded.ssl,
+              user=excluded.user,pwd=excluded.pwd,from_addr=excluded.from_addr,
+              copy_to_self=excluded.copy_to_self,delay_hours=excluded.delay_hours,
+              subj_tpl_presta=excluded.subj_tpl_presta,body_tpl_presta=excluded.body_tpl_presta,
+              subj_tpl_self=excluded.subj_tpl_self,body_tpl_self=excluded.body_tpl_self
+        """;
+        try (PreparedStatement ps = c.prepareStatement(sql)){
+            p.bind(ps);
+            ps.executeUpdate();
+        }catch(SQLException e){ throw new RuntimeException(e);}    }
+}

--- a/src/main/java/org/example/mail/MailPrefs.java
+++ b/src/main/java/org/example/mail/MailPrefs.java
@@ -1,0 +1,69 @@
+package org.example.mail;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public record MailPrefs(
+    String host,
+    int port,
+    boolean ssl,
+    String user,
+    String pwd,
+    String fromAddr,
+    String copyToSelf,
+    int delayHours,
+    String subjTplPresta,
+    String bodyTplPresta,
+    String subjTplSelf,
+    String bodyTplSelf
+) {
+    public static MailPrefs defaultValues() {
+        return new MailPrefs(
+            "smtp.gmail.com",
+            465,
+            true,
+            "",
+            "",
+            "",
+            "",
+            48,
+            "",
+            "",
+            "",
+            ""
+        );
+    }
+
+    public static MailPrefs fromRS(ResultSet rs) throws SQLException {
+        return new MailPrefs(
+            rs.getString("host"),
+            rs.getInt("port"),
+            rs.getInt("ssl") != 0,
+            rs.getString("user"),
+            rs.getString("pwd"),
+            rs.getString("from_addr"),
+            rs.getString("copy_to_self"),
+            rs.getInt("delay_hours"),
+            rs.getString("subj_tpl_presta"),
+            rs.getString("body_tpl_presta"),
+            rs.getString("subj_tpl_self"),
+            rs.getString("body_tpl_self")
+        );
+    }
+
+    public void bind(PreparedStatement ps) throws SQLException {
+        ps.setString(1, host);
+        ps.setInt(2, port);
+        ps.setInt(3, ssl ? 1 : 0);
+        ps.setString(4, user);
+        ps.setString(5, pwd);
+        ps.setString(6, fromAddr);
+        ps.setString(7, copyToSelf);
+        ps.setInt(8, delayHours);
+        ps.setString(9, subjTplPresta);
+        ps.setString(10, bodyTplPresta);
+        ps.setString(11, subjTplSelf);
+        ps.setString(12, bodyTplSelf);
+    }
+}

--- a/src/test/java/org/example/dao/MailPrefsDAOTest.java
+++ b/src/test/java/org/example/dao/MailPrefsDAOTest.java
@@ -1,0 +1,60 @@
+package org.example.dao;
+
+import org.example.mail.MailPrefs;
+import org.junit.jupiter.api.*;
+
+import java.sql.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MailPrefsDAOTest {
+    private Connection conn;
+    private MailPrefsDAO dao;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        conn = DriverManager.getConnection("jdbc:sqlite::memory:");
+        try (Statement st = conn.createStatement()) {
+            st.executeUpdate("""
+                CREATE TABLE mail_prefs (
+                    id INTEGER PRIMARY KEY CHECK(id=1),
+                    host TEXT NOT NULL,
+                    port INTEGER NOT NULL,
+                    ssl INTEGER NOT NULL DEFAULT 1,
+                    user TEXT,
+                    pwd TEXT,
+                    from_addr TEXT NOT NULL,
+                    copy_to_self TEXT,
+                    delay_hours INTEGER NOT NULL DEFAULT 48,
+                    subj_tpl_presta TEXT NOT NULL,
+                    body_tpl_presta TEXT NOT NULL,
+                    subj_tpl_self TEXT NOT NULL,
+                    body_tpl_self TEXT NOT NULL
+                )
+            """);
+        }
+        dao = new MailPrefsDAO(conn);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        conn.close();
+    }
+
+    @Test
+    void testLoadDefaultWhenEmpty() {
+        MailPrefs prefs = dao.load();
+        assertEquals(MailPrefs.defaultValues(), prefs);
+    }
+
+    @Test
+    void testSaveAndLoad() {
+        MailPrefs prefs = new MailPrefs(
+                "smtp.test.com", 25, false, "user", "pwd",
+                "from@test.com", "copy@test.com", 12,
+                "s1", "b1", "s2", "b2");
+        dao.save(prefs);
+        MailPrefs loaded = dao.load();
+        assertEquals(prefs, loaded);
+    }
+}


### PR DESCRIPTION
## Summary
- add `MailPrefs` record for storing mail preferences
- implement `MailPrefsDAO` for CRUD operations on `mail_prefs`
- add unit tests for the DAO

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686995a3ad18832eb34b147059acd677