### PR TITLE
Implement configurable Mailer service

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,20 +15,26 @@ Elle stocke les informations dans une base SQLite locale et propose une interfac
 
 ## Exécution de l'application
 
-Le composant `Mailer` utilise deux variables d'environnement :
+Le composant `Mailer` s'appuie désormais sur la configuration
+fournie par la classe [`MailPrefs`](src/main/java/org/example/mail/MailPrefs.java).
+Par défaut, `MailPrefs.defaultValues()` est utilisée mais vous
+pouvez adapter ces paramètres (serveur SMTP, identifiants, modèles de
+messages) selon votre environnement avant de lancer l'application :
 
-- `MAIL_USER` – adresse utilisée pour envoyer les mails
-- `MAIL_PWD` – mot de passe du compte
+```java
+MailPrefs prefs = MailPrefs.defaultValues();
+// personnaliser si nécessaire :
+// MailPrefs custom = new MailPrefs(...);
+```
 
-Exportez-les avant de démarrer le programme :
+L'exécution se fait ensuite via Maven :
 
 ```bash
-export MAIL_USER="user@example.com"
-export MAIL_PWD="secret"
 mvn javafx:run
 ```
 
-Maven télécharge les dépendances JavaFX nécessaires et lance `org.example.MainApp`.
+Maven télécharge les dépendances JavaFX nécessaires et lance
+`org.example.MainApp`.
 
 Vous pouvez également construire le projet en JAR :
 
@@ -43,17 +49,11 @@ L'archive générée se trouve dans `target/`.
 1. Ouvrez IntelliJ IDEA.
 2. Choisissez **File > Open…** puis sélectionnez le fichier `pom.xml` du projet.
 3. Confirmez l'importation en tant que projet Maven et attendez le téléchargement des dépendances.
-4. Configurez les variables d'environnement `MAIL_USER` et `MAIL_PWD` dans la configuration d'exécution.
-5. Lancez la classe `org.example.MainApp` ou utilisez la commande *Run* proposée par Maven.
+4. Lancez la classe `org.example.MainApp` ou utilisez la commande *Run* proposée par Maven.
 
 ## Sécurité et environnement
 
 Pour envoyer des e‑mails via Gmail vous devez activer les « mots de passe d'application » sur votre compte (ou
-utiliser le serveur SMTP fourni par votre hébergeur). Une fois activés, exportez les variables d'environnement suivantes avant de lancer le programme afin que `Mailer.send()` utilise TLS sur le port 465 :
-
-```bash
-export MAIL_USER="your.address@gmail.com"
-export MAIL_PWD="the_application_password"
-```
-
-Avec ces variables en place, l'envoi de mails doit fonctionner immédiatement.
+utiliser le serveur SMTP fourni par votre hébergeur). Configurez ensuite les paramètres SMTP
+correspondants dans `MailPrefs` (hôte, port, utilisateur, mot de passe, etc.) pour que `Mailer.send()`
+puisse établir la connexion chiffrée sur le port adéquat.

--- a/src/main/java/org/example/MainApp.java
+++ b/src/main/java/org/example/MainApp.java
@@ -6,6 +6,7 @@ import javafx.stage.Stage;
 import org.example.dao.DB;
 import org.example.gui.MainView;
 import org.example.mail.Mailer;
+import org.example.mail.MailPrefs;
 
 import java.util.concurrent.*;
 
@@ -36,7 +37,7 @@ public class MainApp extends Application {
     private void envoyerRappels() {
         dao.rappelsÀEnvoyer().forEach(r -> {
             try {
-                Mailer.send(r.dest(), r.sujet(), r.corps());
+                Mailer.send(MailPrefs.defaultValues(), r.dest(), r.sujet(), r.corps());
                 dao.markRappelEnvoyé(r.id());
                 System.out.println("Rappel envoyé à " + r.dest());
             } catch (Exception ex) {

--- a/src/main/java/org/example/gui/MainView.java
+++ b/src/main/java/org/example/gui/MainView.java
@@ -19,6 +19,7 @@ import org.example.model.Prestataire;
 import org.example.model.Rappel;
 import org.example.pdf.PDF;
 import org.example.mail.Mailer;
+import org.example.mail.MailPrefs;
 
 import java.nio.file.Path;
 import java.time.LocalDate;
@@ -505,7 +506,10 @@ public class MainView {
             if(bt==ButtonType.OK){
                 if(cbNow.isSelected()){
                     runAsync(() -> {
-                        Mailer.send(tfDest.getText(), tfSujet.getText(), taCorps.getText());
+                        Mailer.send(MailPrefs.defaultValues(),
+                                   tfDest.getText(),
+                                   tfSujet.getText(),
+                                   taCorps.getText());
                         return null;
                     }, v -> alert("E‑mail envoyé."));
                 }else{


### PR DESCRIPTION
## Summary
- rework `Mailer` so it uses `MailPrefs` for configuration and provides templating helpers
- update GUI and main application to use new `Mailer` API
- refresh documentation to describe the new configuration method

## Testing
- `javac @sources.txt` *(fails: cannot find jakarta.mail and JavaFX classes)*

------
https://chatgpt.com/codex/tasks/task_e_68699e9bc890832eb240b7943abe4c33