### PR TITLE
Add mail preferences dialog

### DIFF
--- a/src/main/java/org/example/dao/DB.java
+++ b/src/main/java/org/example/dao/DB.java
@@ -124,6 +124,10 @@ public class DB implements AutoCloseable {
         }
     }
 
+    public java.sql.Connection getConnection(){
+        return conn;
+    }
+
     public List<Prestataire> list(String filtre) {
         String sql = """
                 SELECT  p.*, 

--- a/src/main/java/org/example/gui/MailPrefsDialog.java
+++ b/src/main/java/org/example/gui/MailPrefsDialog.java
@@ -1,0 +1,69 @@
+package org.example.gui;
+
+import javafx.scene.control.*;
+import javafx.scene.layout.GridPane;
+import javafx.stage.Stage;
+import org.example.dao.MailPrefsDAO;
+import org.example.mail.MailPrefs;
+
+public class MailPrefsDialog extends Dialog<MailPrefs> {
+    public MailPrefsDialog(MailPrefs current){
+        setTitle("Paramètres e‑mail");
+        getDialogPane().getButtonTypes().addAll(ButtonType.OK, ButtonType.CANCEL);
+
+        TextField tfHost = new TextField(current.host());
+        TextField tfPort = new TextField(String.valueOf(current.port()));
+        CheckBox  cbSSL  = new CheckBox("SSL"); cbSSL.setSelected(current.ssl());
+        TextField tfUser = new TextField(current.user());
+        PasswordField tfPwd = new PasswordField(); tfPwd.setText(current.pwd());
+        TextField tfFrom = new TextField(current.from());
+        TextField tfCopy = new TextField(current.copyToSelf());
+        Spinner<Integer> spDelay = new Spinner<>(1,240,current.delayHours());
+
+        TextArea taSubjP = new TextArea(current.subjPresta());
+        TextArea taBodyP = new TextArea(current.bodyPresta());
+        TextArea taSubjS = new TextArea(current.subjSelf());
+        TextArea taBodyS = new TextArea(current.bodySelf());
+
+        GridPane gp = new GridPane(); gp.setHgap(8); gp.setVgap(6);
+        int r=0;
+        gp.addRow(r++, new Label("SMTP :"), tfHost, new Label("Port"), tfPort, cbSSL);
+        gp.addRow(r++, new Label("Utilisateur :"), tfUser);
+        gp.addRow(r++, new Label("Mot de passe :"), tfPwd);
+        gp.addRow(r++, new Label("Adresse expéditeur :"), tfFrom);
+        gp.addRow(r++, new Label("Copie à (nous) :"), tfCopy);
+        gp.addRow(r++, new Label("Délai pré-avis (h) :"), spDelay);
+        gp.add(new Separator(),0,r++,5,1);
+        gp.addRow(r++, new Label("Sujet → prestataire"), taSubjP);
+        gp.addRow(r++, new Label("Corps → prestataire"), taBodyP);
+        gp.addRow(r++, new Label("Sujet → nous"), taSubjS);
+        gp.addRow(r++, new Label("Corps → nous"), taBodyS);
+
+        getDialogPane().setContent(gp);
+
+        setResultConverter(bt -> {
+            if(bt==ButtonType.OK){
+                return new MailPrefs(tfHost.getText(),
+                        Integer.parseInt(tfPort.getText()),
+                        cbSSL.isSelected(),
+                        tfUser.getText(),
+                        tfPwd.getText(),
+                        tfFrom.getText(),
+                        tfCopy.getText(),
+                        spDelay.getValue(),
+                        taSubjP.getText(),
+                        taBodyP.getText(),
+                        taSubjS.getText(),
+                        taBodyS.getText());
+            }
+            return null;
+        });
+    }
+
+    /** sucré-salé : test d'envoi live */
+    public static void open(Stage owner, MailPrefsDAO dao){
+        MailPrefsDialog d = new MailPrefsDialog(dao.load());
+        d.setHeaderText("Configurer le serveur SMTP, modèles et délai.");
+        d.showAndWait().ifPresent(cfg -> dao.save(cfg));
+    }
+}

--- a/src/main/java/org/example/gui/MainView.java
+++ b/src/main/java/org/example/gui/MainView.java
@@ -20,6 +20,8 @@ import org.example.model.Rappel;
 import org.example.pdf.PDF;
 import org.example.mail.Mailer;
 import org.example.mail.MailPrefs;
+import org.example.dao.MailPrefsDAO;
+import org.example.gui.MailPrefsDialog;
 
 import java.nio.file.Path;
 import java.time.LocalDate;
@@ -35,6 +37,7 @@ public class MainView {
 
     private final BorderPane root = new BorderPane();
     private final DB dao;
+    private final MailPrefsDAO mailPrefsDao;
 
     private final ExecutorService executor = Executors.newSingleThreadExecutor(r -> new Thread(r, "gui-bg"));
 
@@ -45,6 +48,7 @@ public class MainView {
 
     public MainView(Stage stage, DB dao) {
         this.dao = dao;
+        this.mailPrefsDao = new MailPrefsDAO(dao.getConnection());
         buildLayout(stage);
         refresh("");
         stage.setOnCloseRequest(e -> executor.shutdown());
@@ -179,6 +183,7 @@ public class MainView {
         Button bFact = new Button("Factures");
         Button bPDF = new Button("Fiche PDF");
         Button bPDFAll = new Button("PDF global");
+        Button bPrefsMail = new Button("Mail…");
 
         bAdd.getStyleClass().add("accent");
         bFact.getStyleClass().add("accent");
@@ -222,7 +227,8 @@ public class MainView {
             }
         });
 
-        HBox hb = new HBox(16, bAdd, bEdit, bDel, bService, bHist, bFact, bPDF, bPDFAll);
+        bPrefsMail.setOnAction(e -> MailPrefsDialog.open(stage, mailPrefsDao));
+        HBox hb = new HBox(16, bAdd, bEdit, bDel, bService, bHist, bFact, bPDF, bPDFAll, bPrefsMail);
         hb.setPadding(new Insets(10));
         hb.setAlignment(Pos.CENTER_LEFT);
         return hb;


### PR DESCRIPTION
## Summary
- implement `MailPrefsDialog` for configuring SMTP settings
- expose DB connection via `getConnection`
- add a "Mail…" button in the main view to open the dialog

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a9bae038832ea1f2bfac0d093268