### PR TITLE
Introduce ThemeManager for consistent styling

### DIFF
--- a/src/main/java/org/example/MainApp.java
+++ b/src/main/java/org/example/MainApp.java
@@ -6,6 +6,7 @@ import javafx.stage.Stage;
 import org.example.dao.DB;
 import org.example.dao.MailPrefsDAO;
 import org.example.gui.MainView;
+import org.example.gui.ThemeManager;
 import org.example.mail.Mailer;
 import org.example.mail.MailPrefs;
 import org.example.model.Prestataire;
@@ -33,7 +34,7 @@ public class MainApp extends Application {
         view = new MainView(primaryStage, dao, mailPrefsDao);
         primaryStage.setTitle("Gestion des Prestataires");
         Scene sc = new Scene(view.getRoot(), 920, 600);
-        sc.getStylesheets().add(getClass().getResource("/css/dark.css").toExternalForm());
+        org.example.gui.ThemeManager.apply(sc);
         primaryStage.setScene(sc);
         primaryStage.show();
 

--- a/src/main/java/org/example/gui/MailPrefsDialog.java
+++ b/src/main/java/org/example/gui/MailPrefsDialog.java
@@ -5,6 +5,7 @@ import javafx.scene.layout.GridPane;
 import javafx.stage.Stage;
 import org.example.dao.MailPrefsDAO;
 import org.example.mail.MailPrefs;
+import org.example.gui.ThemeManager;
 
 public class MailPrefsDialog extends Dialog<MailPrefs> {
     public MailPrefsDialog(MailPrefs current){
@@ -63,6 +64,7 @@ public class MailPrefsDialog extends Dialog<MailPrefs> {
     /** sucré-salé : test d'envoi live */
     public static void open(Stage owner, MailPrefsDAO dao){
         MailPrefsDialog d = new MailPrefsDialog(dao.load());
+        ThemeManager.apply(d);
         d.setHeaderText("Configurer le serveur SMTP, modèles et délai.");
         d.showAndWait().ifPresent(cfg -> dao.save(cfg));
     }

--- a/src/main/java/org/example/gui/MainView.java
+++ b/src/main/java/org/example/gui/MainView.java
@@ -22,6 +22,7 @@ import org.example.mail.Mailer;
 import org.example.mail.MailPrefs;
 import org.example.dao.MailPrefsDAO;
 import org.example.gui.MailPrefsDialog;
+import org.example.gui.ThemeManager;
 
 import java.nio.file.Path;
 import java.time.LocalDate;
@@ -244,6 +245,7 @@ public class MainView {
 
     private void editDialog(Prestataire src) {
         Dialog<Prestataire> d = new Dialog<>();
+        ThemeManager.apply(d);
         d.setTitle(src == null ? "Nouveau Prestataire" : "Modifier Prestataire");
         d.getDialogPane().getButtonTypes().addAll(ButtonType.OK, ButtonType.CANCEL);
 
@@ -317,6 +319,7 @@ public class MainView {
             return;
         }
         TextInputDialog td = new TextInputDialog();
+        ThemeManager.apply(td);
         td.setTitle("Nouveau service");
         td.setHeaderText("Description du service");
         td.showAndWait().ifPresent(desc -> {
@@ -340,7 +343,7 @@ public class MainView {
         vb.setPadding(new Insets(10));
         vb.getChildren().add(new Label("Chargement..."));
         Scene sc = new Scene(new ScrollPane(vb), 400, 400);
-        sc.getStylesheets().add(getClass().getResource("/css/dark.css").toExternalForm());
+        ThemeManager.apply(sc);
         win.setScene(sc);
         win.initModality(Modality.WINDOW_MODAL);
         win.show();
@@ -429,7 +432,7 @@ public class MainView {
         VBox root = new VBox(10, title, tv, buttons);
         root.setPadding(new Insets(10));
         Scene sc = new Scene(root, 600, 400);
-        sc.getStylesheets().add(getClass().getResource("/css/dark.css").toExternalForm());
+        ThemeManager.apply(sc);
         win.setScene(sc);
         win.initModality(Modality.WINDOW_MODAL);
         win.show();
@@ -454,6 +457,7 @@ public class MainView {
 
     private void addFactureDialog(Prestataire p, TableView<Facture> tv){
         Dialog<Facture> d = new Dialog<>();
+        ThemeManager.apply(d);
         d.setTitle("Nouvelle facture – "+p.getNom());
         d.getDialogPane().getButtonTypes().addAll(ButtonType.OK, ButtonType.CANCEL);
 
@@ -484,6 +488,7 @@ public class MainView {
 
     private void afficherDialogRappel(Prestataire pr, Facture f){
         Dialog<Void> dlg = new Dialog<>();
+        ThemeManager.apply(dlg);
         dlg.setTitle("Rappel – "+pr.getNom());
 
         GridPane gp = new GridPane(); gp.setHgap(8); gp.setVgap(10);
@@ -543,12 +548,15 @@ public class MainView {
     }
 
     private boolean confirm(String msg) {
-        return new Alert(Alert.AlertType.CONFIRMATION, msg, ButtonType.YES, ButtonType.NO)
-                .showAndWait().orElse(ButtonType.NO) == ButtonType.YES;
+        Alert a = new Alert(Alert.AlertType.CONFIRMATION, msg, ButtonType.YES, ButtonType.NO);
+        ThemeManager.apply(a);
+        return a.showAndWait().orElse(ButtonType.NO) == ButtonType.YES;
     }
 
     private void alert(String msg) {
-        new Alert(Alert.AlertType.ERROR, msg, ButtonType.OK).showAndWait();
+        Alert a = new Alert(Alert.AlertType.ERROR, msg, ButtonType.OK);
+        ThemeManager.apply(a);
+        a.showAndWait();
     }
 
     public void shutdownExecutor() {

--- a/src/main/java/org/example/gui/ThemeManager.java
+++ b/src/main/java/org/example/gui/ThemeManager.java
@@ -1,0 +1,28 @@
+package org.example.gui;
+
+import javafx.scene.Scene;
+import javafx.scene.control.Dialog;
+import javafx.scene.control.DialogPane;
+
+/** Utility class for applying the global CSS theme. */
+public final class ThemeManager {
+    private static final String THEME =
+            ThemeManager.class.getResource("/css/dark.css").toExternalForm();
+
+    private ThemeManager() {}
+
+    /** Apply the application stylesheet to the given scene. */
+    public static void apply(Scene scene) {
+        if (scene != null && !scene.getStylesheets().contains(THEME)) {
+            scene.getStylesheets().add(THEME);
+        }
+    }
+
+    /** Apply the application stylesheet to the given dialog. */
+    public static void apply(Dialog<?> dialog) {
+        DialogPane pane = dialog.getDialogPane();
+        if (pane != null && !pane.getStylesheets().contains(THEME)) {
+            pane.getStylesheets().add(THEME);
+        }
+    }
+}

--- a/src/main/java/org/example/pdf/PDF.java
+++ b/src/main/java/org/example/pdf/PDF.java
@@ -11,6 +11,7 @@ import javafx.stage.FileChooser;
 import javafx.stage.Stage;
 import org.example.dao.DB;
 import org.example.model.Prestataire;
+import org.example.gui.ThemeManager;
 
 import java.io.FileOutputStream;
 import java.nio.file.Path;
@@ -83,10 +84,14 @@ public class PDF {
     }
 
     private static void info(String m) {
-        new Alert(Alert.AlertType.INFORMATION, m, ButtonType.OK).showAndWait();
+        Alert a = new Alert(Alert.AlertType.INFORMATION, m, ButtonType.OK);
+        ThemeManager.apply(a);
+        a.showAndWait();
     }
 
     private static void error(String m) {
-        new Alert(Alert.AlertType.ERROR, m, ButtonType.OK).showAndWait();
+        Alert a = new Alert(Alert.AlertType.ERROR, m, ButtonType.OK);
+        ThemeManager.apply(a);
+        a.showAndWait();
     }
 }


### PR DESCRIPTION
## Summary
- add `ThemeManager` utility to centralize stylesheet application
- use `ThemeManager` for the main scene and dialogs
- update MailPrefs dialog and PDF alerts to use new styling helper

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869ba70f3fc832eb21c857a93c7838d