### PR TITLE
Fix missing Insets import

### DIFF
--- a/src/main/java/org/example/gui/MailPrefsDialog.java
+++ b/src/main/java/org/example/gui/MailPrefsDialog.java
@@ -2,6 +2,7 @@ package org.example.gui;
 
 import javafx.scene.control.*;
 import javafx.scene.layout.GridPane;
+import javafx.geometry.Insets;
 import javafx.stage.Stage;
 import org.example.dao.MailPrefsDAO;
 import org.example.mail.MailPrefs;


### PR DESCRIPTION
## Summary
- add missing `Insets` import to `MailPrefsDialog`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a773f79e0832e9759b2648f7b15c7