### PR TITLE
Add OAuth settings to MailPrefs

### DIFF
--- a/src/main/java/org/example/dao/DB.java
+++ b/src/main/java/org/example/dao/DB.java
@@ -94,6 +94,10 @@ public class DB implements AutoCloseable {
                             ssl              INTEGER NOT NULL DEFAULT 1,
                             user             TEXT,
                             pwd              TEXT,
+                            provider         TEXT,
+                            oauth_client     TEXT,
+                            oauth_refresh    TEXT,
+                            oauth_expiry     INTEGER,
                             from_addr        TEXT  NOT NULL,
                             copy_to_self     TEXT,
                             delay_hours      INTEGER NOT NULL DEFAULT 48,
@@ -109,6 +113,19 @@ public class DB implements AutoCloseable {
                     ALTER TABLE factures
                     ADD COLUMN preavis_envoye INTEGER NOT NULL DEFAULT 0
                 """);
+            } catch (SQLException ignore) {}
+            // ajout progressif des colonnes OAuth pour mail_prefs
+            try (Statement st = conn.createStatement()) {
+                st.executeUpdate("ALTER TABLE mail_prefs ADD COLUMN provider TEXT");
+            } catch (SQLException ignore) {}
+            try (Statement st = conn.createStatement()) {
+                st.executeUpdate("ALTER TABLE mail_prefs ADD COLUMN oauth_client TEXT");
+            } catch (SQLException ignore) {}
+            try (Statement st = conn.createStatement()) {
+                st.executeUpdate("ALTER TABLE mail_prefs ADD COLUMN oauth_refresh TEXT");
+            } catch (SQLException ignore) {}
+            try (Statement st = conn.createStatement()) {
+                st.executeUpdate("ALTER TABLE mail_prefs ADD COLUMN oauth_expiry INTEGER");
             } catch (SQLException ignore) {}
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/src/main/java/org/example/dao/MailPrefsDAO.java
+++ b/src/main/java/org/example/dao/MailPrefsDAO.java
@@ -16,13 +16,16 @@ public class MailPrefsDAO {
         } catch(SQLException e){ throw new RuntimeException(e);}    }
     public void save(MailPrefs p){
         String sql = """
-            INSERT INTO mail_prefs(id,host,port,ssl,user,pwd,from_addr,copy_to_self,
-                                   delay_hours,subj_tpl_presta,body_tpl_presta,
+            INSERT INTO mail_prefs(id,host,port,ssl,user,pwd,provider,oauth_client,oauth_refresh,oauth_expiry,
+                                   from_addr,copy_to_self,delay_hours,subj_tpl_presta,body_tpl_presta,
                                    subj_tpl_self,body_tpl_self)
-            VALUES(1,?,?,?,?,?,?,?,?,?,?,?,?)
+            VALUES(1,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
             ON CONFLICT(id) DO UPDATE SET
               host=excluded.host,port=excluded.port,ssl=excluded.ssl,
-              user=excluded.user,pwd=excluded.pwd,from_addr=excluded.from_addr,
+              user=excluded.user,pwd=excluded.pwd,
+              provider=excluded.provider,oauth_client=excluded.oauth_client,
+              oauth_refresh=excluded.oauth_refresh,oauth_expiry=excluded.oauth_expiry,
+              from_addr=excluded.from_addr,
               copy_to_self=excluded.copy_to_self,delay_hours=excluded.delay_hours,
               subj_tpl_presta=excluded.subj_tpl_presta,body_tpl_presta=excluded.body_tpl_presta,
               subj_tpl_self=excluded.subj_tpl_self,body_tpl_self=excluded.body_tpl_self

--- a/src/test/java/org/example/dao/MailPrefsDAOTest.java
+++ b/src/test/java/org/example/dao/MailPrefsDAOTest.java
@@ -23,6 +23,10 @@ public class MailPrefsDAOTest {
                     ssl INTEGER NOT NULL DEFAULT 1,
                     user TEXT,
                     pwd TEXT,
+                    provider TEXT,
+                    oauth_client TEXT,
+                    oauth_refresh TEXT,
+                    oauth_expiry INTEGER,
                     from_addr TEXT NOT NULL,
                     copy_to_self TEXT,
                     delay_hours INTEGER NOT NULL DEFAULT 48,
@@ -50,7 +54,9 @@ public class MailPrefsDAOTest {
     @Test
     void testSaveAndLoad() {
         MailPrefs prefs = new MailPrefs(
-                "smtp.test.com", 25, false, "user", "pwd",
+                "smtp.test.com", 25, false,
+                "user", "pwd",
+                "google", "client", "refresh", 123L,
                 "from@test.com", "copy@test.com", 12,
                 "s1", "b1", "s2", "b2");
         dao.save(prefs);


### PR DESCRIPTION
## Summary
- extend `mail_prefs` table with OAuth columns
- expose new fields in `MailPrefs`
- update `MailPrefsDAO` to read/write OAuth data
- migrate existing DBs to the new schema
- adapt DAO tests to the new structure

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686ac3c2119c832ea98b9c16fdcb5f79