### PR TITLE
Add Gmail wizard and update UI

### DIFF
--- a/src/main/java/org/example/gui/MailWizardDialog.java
+++ b/src/main/java/org/example/gui/MailWizardDialog.java
@@ -1,0 +1,99 @@
+package org.example.gui;
+
+import javafx.geometry.Insets;
+import javafx.scene.control.*;
+import javafx.scene.layout.GridPane;
+import javafx.stage.Stage;
+import org.example.dao.MailPrefsDAO;
+import org.example.mail.GoogleAuthService;
+import org.example.mail.MailPrefs;
+
+/**
+ * Simple wizard to configure e-mail templates and recipients.
+ */
+public class MailWizardDialog extends Dialog<MailPrefs> {
+    public MailWizardDialog(MailPrefs current, MailPrefsDAO dao) {
+        setTitle("Assistant e-mail");
+        setResizable(true);
+        getDialogPane().setPrefSize(700, 500);
+        getDialogPane().getButtonTypes().addAll(ButtonType.OK, ButtonType.CANCEL);
+
+        // keep prefs when Gmail login updates them
+        final MailPrefs[] prefsBox = { current };
+
+        Button bLogin = new Button("Connexion Gmail...");
+        bLogin.getStyleClass().add("accent");
+        bLogin.setOnAction(ev -> {
+            try {
+                new GoogleAuthService(dao).interactiveAuth();
+                prefsBox[0] = dao.load();
+                Alert a = new Alert(Alert.AlertType.INFORMATION, "Authentification réussie", ButtonType.OK);
+                ThemeManager.apply(a);
+                a.showAndWait();
+            } catch (Exception ex) {
+                Alert a = new Alert(Alert.AlertType.ERROR, ex.getMessage(), ButtonType.OK);
+                ThemeManager.apply(a);
+                a.showAndWait();
+            }
+        });
+
+        TextField tfFrom = new TextField(current.from());
+        TextField tfCopy = new TextField(current.copyToSelf());
+        Spinner<Integer> spDelay = new Spinner<>(1, 240, current.delayHours());
+
+        TextArea taSubjP = new TextArea(current.subjPresta());
+        taSubjP.setPrefRowCount(2);
+        TextArea taBodyP = new TextArea(current.bodyPresta());
+        taBodyP.setPrefRowCount(3);
+        TextArea taSubjS = new TextArea(current.subjSelf());
+        taSubjS.setPrefRowCount(2);
+        TextArea taBodyS = new TextArea(current.bodySelf());
+        taBodyS.setPrefRowCount(3);
+
+        Label vars = new Label("Variables : %NOM%, %EMAIL%, %MONTANT%, %ECHEANCE%, %ID%");
+        vars.getStyleClass().add("caption");
+
+        GridPane gp = new GridPane();
+        gp.setHgap(8);
+        gp.setVgap(6);
+        gp.setPadding(new Insets(12));
+        int r = 0;
+        gp.add(bLogin, 0, r++, 2, 1);
+        gp.addRow(r++, new Label("Adresse expéditeur :"), tfFrom);
+        gp.addRow(r++, new Label("Copie à (nous) :"), tfCopy);
+        gp.addRow(r++, new Label("Délai pré-avis (h) :"), spDelay);
+        gp.add(new Separator(), 0, r++, 2, 1);
+        gp.addRow(r++, new Label("Sujet → prestataire"), taSubjP);
+        gp.addRow(r++, new Label("Corps → prestataire"), taBodyP);
+        gp.addRow(r++, new Label("Sujet → nous"), taSubjS);
+        gp.addRow(r++, new Label("Corps → nous"), taBodyS);
+        gp.add(vars, 0, r++, 2, 1);
+
+        getDialogPane().setContent(gp);
+
+        setResultConverter(bt -> {
+            if (bt == ButtonType.OK) {
+                MailPrefs base = prefsBox[0];
+                return new MailPrefs(
+                        base.host(), base.port(), base.ssl(),
+                        base.user(), base.pwd(),
+                        base.provider(), base.oauthClient(),
+                        base.oauthRefresh(), base.oauthExpiry(),
+                        tfFrom.getText(), tfCopy.getText(),
+                        spDelay.getValue(),
+                        taSubjP.getText(), taBodyP.getText(),
+                        taSubjS.getText(), taBodyS.getText()
+                );
+            }
+            return null;
+        });
+    }
+
+    /** Utility entry point to open the wizard */
+    public static void open(Stage owner, MailPrefsDAO dao) {
+        MailWizardDialog d = new MailWizardDialog(dao.load(), dao);
+        ThemeManager.apply(d);
+        d.setHeaderText("Configurer l'envoi des e-mails");
+        d.showAndWait().ifPresent(cfg -> dao.save(cfg));
+    }
+}

--- a/src/main/java/org/example/gui/MainView.java
+++ b/src/main/java/org/example/gui/MainView.java
@@ -21,7 +21,7 @@ import org.example.pdf.PDF;
 import org.example.mail.Mailer;
 import org.example.mail.MailPrefs;
 import org.example.dao.MailPrefsDAO;
-import org.example.gui.MailPrefsDialog;
+import org.example.gui.MailWizardDialog;
 import org.example.gui.ThemeManager;
 
 import java.nio.file.Path;
@@ -239,7 +239,7 @@ public class MainView {
             }
         });
 
-        bPrefsMail.setOnAction(e -> MailPrefsDialog.open(stage, mailPrefsDao));
+        bPrefsMail.setOnAction(e -> MailWizardDialog.open(stage, mailPrefsDao));
         HBox hb = new HBox(16, bAdd, bEdit, bDel, bService, bHist, bFact, bPDF, bPDFAll, bPrefsMail);
         hb.setPadding(new Insets(10));
         hb.setAlignment(Pos.CENTER_LEFT);


### PR DESCRIPTION
## Summary
- add `MailWizardDialog` wizard for configuring mail templates
- call `GoogleAuthService` for Gmail login within the wizard
- replace old preferences dialog usage in `MainView`

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ac9aec44c832ea2005c377726d46d