### PR TITLE
Add OAuth persistence tests

### DIFF
--- a/src/test/java/org/example/dao/MailPrefsDAOTest.java
+++ b/src/test/java/org/example/dao/MailPrefsDAOTest.java
@@ -49,6 +49,10 @@ public class MailPrefsDAOTest {
     void testLoadDefaultWhenEmpty() {
         MailPrefs prefs = dao.load();
         assertEquals(MailPrefs.defaultValues(), prefs);
+        assertEquals("", prefs.provider());
+        assertEquals("", prefs.oauthClient());
+        assertEquals("", prefs.oauthRefresh());
+        assertEquals(0L, prefs.oauthExpiry());
     }
 
     @Test
@@ -56,11 +60,36 @@ public class MailPrefsDAOTest {
         MailPrefs prefs = new MailPrefs(
                 "smtp.test.com", 25, false,
                 "user", "pwd",
-                "google", "client", "refresh", 123L,
+                "gmail", "client:secret", "refresh", 123L,
                 "from@test.com", "copy@test.com", 12,
                 "s1", "b1", "s2", "b2");
         dao.save(prefs);
         MailPrefs loaded = dao.load();
         assertEquals(prefs, loaded);
+    }
+
+    @Test
+    void testRefreshTokenPersists() {
+        MailPrefs prefs = new MailPrefs(
+                "smtp.test.com", 25, false,
+                "user", "pwd",
+                "gmail", "client:secret", "tok1", 100L,
+                "from@test.com", null, 12,
+                "s1", "b1", "s2", "b2");
+        dao.save(prefs);
+
+        MailPrefs updated = new MailPrefs(
+                prefs.host(), prefs.port(), prefs.ssl(),
+                prefs.user(), prefs.pwd(),
+                prefs.provider(), prefs.oauthClient(), prefs.oauthRefresh(),
+                200L,
+                prefs.from(), prefs.copyToSelf(), prefs.delayHours(),
+                prefs.subjPresta(), prefs.bodyPresta(),
+                prefs.subjSelf(), prefs.bodySelf());
+        dao.save(updated);
+
+        MailPrefs loaded = dao.load();
+        assertEquals("tok1", loaded.oauthRefresh());
+        assertEquals(200L, loaded.oauthExpiry());
     }
 }

--- a/src/test/java/org/example/mail/GoogleAuthServiceTest.java
+++ b/src/test/java/org/example/mail/GoogleAuthServiceTest.java
@@ -1,0 +1,127 @@
+package org.example.mail;
+
+import org.example.dao.MailPrefsDAO;
+import org.junit.jupiter.api.*;
+
+import java.lang.reflect.Field;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpClient.Version;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class GoogleAuthServiceTest {
+    private Connection conn;
+    private MailPrefsDAO dao;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        conn = DriverManager.getConnection("jdbc:sqlite::memory:");
+        try (Statement st = conn.createStatement()) {
+            st.executeUpdate("""
+                CREATE TABLE mail_prefs (
+                    id INTEGER PRIMARY KEY CHECK(id=1),
+                    host TEXT NOT NULL,
+                    port INTEGER NOT NULL,
+                    ssl INTEGER NOT NULL DEFAULT 1,
+                    user TEXT,
+                    pwd TEXT,
+                    provider TEXT,
+                    oauth_client TEXT,
+                    oauth_refresh TEXT,
+                    oauth_expiry INTEGER,
+                    from_addr TEXT NOT NULL,
+                    copy_to_self TEXT,
+                    delay_hours INTEGER NOT NULL DEFAULT 48,
+                    subj_tpl_presta TEXT NOT NULL,
+                    body_tpl_presta TEXT NOT NULL,
+                    subj_tpl_self TEXT NOT NULL,
+                    body_tpl_self TEXT NOT NULL
+                )
+            """);
+        }
+        dao = new MailPrefsDAO(conn);
+        MailPrefs prefs = new MailPrefs(
+                "smtp.gmail.com", 465, true,
+                "user", "pwd",
+                "gmail", "id:secret", "refresh", 0L,
+                "from@test.com", null, 48,
+                "s1", "b1", "s2", "b2");
+        dao.save(prefs);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        conn.close();
+    }
+
+    @Test
+    void testTokenRefresh() throws Exception {
+        GoogleAuthService gs = new GoogleAuthService(dao);
+        // inject stub client
+        StubHttpClient stub = new StubHttpClient("{\"access_token\":\"tok\",\"expires_in\":3600}");
+        Field f = GoogleAuthService.class.getDeclaredField("http");
+        f.setAccessible(true);
+        f.set(gs, stub);
+
+        String token = gs.getAccessToken();
+        assertEquals("tok", token);
+        assertNotNull(stub.lastRequest);
+        assertTrue(stub.lastRequest.bodyPublisher().isPresent());
+
+        MailPrefs stored = dao.load();
+        assertEquals("refresh", stored.oauthRefresh());
+        assertTrue(stored.oauthExpiry() > 0);
+    }
+
+    private static class StubHttpClient extends HttpClient {
+        final String body;
+        final HttpClient delegate = HttpClient.newHttpClient();
+        HttpRequest lastRequest;
+        StubHttpClient(String body) { this.body = body; }
+        @Override
+        public <T> HttpResponse<T> send(HttpRequest request, HttpResponse.BodyHandler<T> handler) {
+            this.lastRequest = request;
+            return (HttpResponse<T>) new SimpleResponse(request, body);
+        }
+        @Override
+        public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest request, HttpResponse.BodyHandler<T> handler) {
+            return CompletableFuture.completedFuture(send(request, handler));
+        }
+        @Override
+        public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest req, HttpResponse.BodyHandler<T> h, HttpResponse.PushPromiseHandler<T> p) {
+            return CompletableFuture.completedFuture(send(req, h));
+        }
+        private static class SimpleResponse implements HttpResponse<String> {
+            private final HttpRequest req;
+            private final String body;
+            SimpleResponse(HttpRequest req, String body) { this.req = req; this.body = body; }
+            public int statusCode() { return 200; }
+            public HttpRequest request() { return req; }
+            public Optional<HttpResponse<String>> previousResponse() { return Optional.empty(); }
+            public HttpHeaders headers() { return HttpHeaders.of(Map.of(), (a,b)->true); }
+            public String body() { return body; }
+            public Optional<javax.net.ssl.SSLSession> sslSession() { return Optional.empty(); }
+            public java.net.URI uri() { return req.uri(); }
+            public Version version() { return Version.HTTP_1_1; }
+        }
+        public Optional<java.net.ProxySelector> proxy() { return delegate.proxy(); }
+        public Optional<java.net.Authenticator> authenticator() { return delegate.authenticator(); }
+        public java.net.CookieHandler cookieHandler() { return delegate.cookieHandler().orElse(null); }
+        public java.time.Duration connectTimeout() { return delegate.connectTimeout().orElse(null); }
+        public java.net.http.HttpClient.Redirect followRedirects() { return delegate.followRedirects(); }
+        public javax.net.ssl.SSLContext sslContext() { return delegate.sslContext(); }
+        public javax.net.ssl.SSLParameters sslParameters() { return delegate.sslParameters(); }
+        public java.net.http.HttpClient.Version version() { return delegate.version(); }
+        public java.util.Optional<java.util.concurrent.Executor> executor() { return delegate.executor(); }
+        public java.net.http.HttpClient.Builder newBuilder() { return delegate.newBuilder(); }
+        public void close() { delegate.close(); }
+    }
+}


### PR DESCRIPTION
## Summary
- extend MailPrefsDAO tests for OAuth columns
- ensure refresh token persists when updating
- add unit test for GoogleAuthService token refresh

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686acd417474832eb64e81de6174061f