### PR TITLE
Fix regex escaping in jsonLong

### DIFF
--- a/src/main/java/org/example/mail/GoogleAuthService.java
+++ b/src/main/java/org/example/mail/GoogleAuthService.java
@@ -160,7 +160,7 @@ public class GoogleAuthService {
     }
 
     private static long jsonLong(String body, String key) {
-        Matcher m = Pattern.compile("\"" + key + "\"\\s*:\\s*(\d+)").matcher(body);
+        Matcher m = Pattern.compile("\"" + key + "\"\\s*:\\s*(\\d+)").matcher(body);
         return m.find() ? Long.parseLong(m.group(1)) : 0L;
     }
 


### PR DESCRIPTION
## Summary
- fix the regex in `GoogleAuthService.jsonLong` so the string compiles

## Testing
- `javac src/main/java/org/example/mail/GoogleAuthService.java` *(fails: package org.example.dao does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_686ad7f547f0832e8c3c5ecefc319818