### PR TITLE
Add mail quick setup with SMTP presets

### DIFF
--- a/src/main/java/org/example/gui/MailQuickSetupDialog.java
+++ b/src/main/java/org/example/gui/MailQuickSetupDialog.java
@@ -1,0 +1,200 @@
+package org.example.gui;
+
+import javafx.beans.binding.BooleanBinding;
+import javafx.beans.binding.Bindings;
+import javafx.collections.FXCollections;
+import javafx.geometry.Insets;
+import javafx.scene.control.*;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+import org.example.dao.MailPrefsDAO;
+import org.example.mail.GoogleAuthService;
+import org.example.mail.MailPrefs;
+import org.example.mail.Mailer;
+import org.example.mail.SmtpPreset;
+
+/** Dialog providing simplified e‑mail configuration using provider presets. */
+public class MailQuickSetupDialog extends Dialog<MailPrefs> {
+    public MailQuickSetupDialog(MailPrefs current, MailPrefsDAO dao) {
+        setTitle("Paramètres e-mail");
+        setResizable(true);
+        getDialogPane().setPrefSize(680, 520);
+        getDialogPane().getButtonTypes().addAll(ButtonType.OK, ButtonType.CANCEL);
+
+        final MailPrefs[] prefsBox = { current };
+
+        ComboBox<SmtpPreset> cbProv = new ComboBox<>(FXCollections.observableArrayList(SmtpPreset.PRESETS));
+        SmtpPreset sel = SmtpPreset.byProvider(current.provider());
+        if (sel == null) sel = SmtpPreset.PRESETS[0];
+        cbProv.getSelectionModel().select(sel);
+
+        TextField tfHost = new TextField(current.host());
+        tfHost.setTooltip(new Tooltip("Serveur SMTP"));
+        TextField tfPort = new TextField(String.valueOf(current.port()));
+        tfPort.setTooltip(new Tooltip("Port SMTP"));
+        CheckBox cbSSL = new CheckBox("SSL");
+        cbSSL.setSelected(current.ssl());
+        cbSSL.setTooltip(new Tooltip("Connexion sécurisée"));
+        TextField tfUser = new TextField(current.user());
+        tfUser.setTooltip(new Tooltip("Utilisateur SMTP"));
+        PasswordField tfPwd = new PasswordField();
+        tfPwd.setText(current.pwd());
+        tfPwd.setTooltip(new Tooltip("Mot de passe SMTP"));
+        TextField tfFrom = new TextField(current.from());
+        tfFrom.setTooltip(new Tooltip("Adresse expéditeur"));
+        TextField tfCopy = new TextField(current.copyToSelf());
+        tfCopy.setTooltip(new Tooltip("Copie des préavis"));
+        Spinner<Integer> spDelay = new Spinner<>(1, 240, current.delayHours());
+        spDelay.setTooltip(new Tooltip("Délai pré-avis interne (heures)"));
+
+        Button bOAuth = new Button("Connexion Gmail...");
+        bOAuth.getStyleClass().add("accent");
+        bOAuth.setVisible(sel.oauth());
+        bOAuth.setOnAction(ev -> {
+            try {
+                new GoogleAuthService(dao).interactiveAuth();
+                prefsBox[0] = dao.load();
+                Alert a = new Alert(Alert.AlertType.INFORMATION, "Authentification réussie", ButtonType.OK);
+                ThemeManager.apply(a);
+                a.showAndWait();
+            } catch (Exception ex) {
+                Alert a = new Alert(Alert.AlertType.ERROR, ex.getMessage(), ButtonType.OK);
+                ThemeManager.apply(a);
+                a.showAndWait();
+            }
+        });
+
+        Button bTest = new Button("Tester l'envoi");
+        bTest.getStyleClass().add("accent");
+
+        // react to provider change
+        cbProv.getSelectionModel().selectedItemProperty().addListener((o, p, n) -> {
+            if (n != null) {
+                tfHost.setText(n.host());
+                tfPort.setText(String.valueOf(n.port()));
+                cbSSL.setSelected(n.ssl());
+                bOAuth.setVisible(n.oauth());
+            }
+        });
+
+        GridPane gp = new GridPane();
+        gp.setHgap(8); gp.setVgap(6); gp.setPadding(new Insets(12));
+        int r = 0;
+        gp.addRow(r++, new Label("Fournisseur :"), cbProv);
+        gp.addRow(r++, new Label("SMTP :"), tfHost, new Label("Port"), tfPort, cbSSL);
+        gp.addRow(r++, new Label("Utilisateur :"), tfUser);
+        gp.addRow(r++, new Label("Mot de passe :"), tfPwd);
+        gp.addRow(r++, new Label("Adresse expéditeur :"), tfFrom);
+        gp.addRow(r++, new Label("Copie à (nous) :"), tfCopy);
+        gp.addRow(r++, new Label("Délai pré-avis (h) :"), spDelay);
+        gp.add(bOAuth, 0, r++, 5, 1);
+        gp.add(bTest, 0, r++, 5, 1);
+
+        TextArea taSubjP = new TextArea(current.subjPresta());
+        taSubjP.setPrefRowCount(2);
+        TextArea taBodyP = new TextArea(current.bodyPresta());
+        taBodyP.setPrefRowCount(3);
+        TextArea taSubjS = new TextArea(current.subjSelf());
+        taSubjS.setPrefRowCount(2);
+        TextArea taBodyS = new TextArea(current.bodySelf());
+        taBodyS.setPrefRowCount(3);
+        Label vars = new Label("Variables : %NOM%, %EMAIL%, %MONTANT%, %ECHEANCE%, %ID%");
+        vars.getStyleClass().add("caption");
+
+        GridPane gpTpl = new GridPane();
+        gpTpl.setHgap(8); gpTpl.setVgap(6); gpTpl.setPadding(new Insets(12));
+        int t = 0;
+        gpTpl.addRow(t++, new Label("Sujet → prestataire"), taSubjP);
+        gpTpl.addRow(t++, new Label("Corps → prestataire"), taBodyP);
+        gpTpl.addRow(t++, new Label("Sujet → nous"), taSubjS);
+        gpTpl.addRow(t++, new Label("Corps → nous"), taBodyS);
+        gpTpl.add(vars, 0, t++, 2, 1);
+        TitledPane adv = new TitledPane("Options avancées", gpTpl);
+        adv.setExpanded(false);
+
+        VBox root = new VBox(gp, adv);
+        getDialogPane().setContent(root);
+
+        // validation bindings (same as MailSettingsDialog)
+        BooleanBinding portInvalid = Bindings.createBooleanBinding(() -> {
+            try { Integer.parseInt(tfPort.getText()); return false; } catch(Exception e) { return true; }
+        }, tfPort.textProperty());
+        BooleanBinding invalid = tfHost.textProperty().isEmpty()
+                .or(tfUser.textProperty().isEmpty())
+                .or(tfFrom.textProperty().isEmpty())
+                .or(portInvalid);
+        Button ok = (Button) getDialogPane().lookupButton(ButtonType.OK);
+        ok.disableProperty().bind(invalid);
+
+        bTest.setOnAction(ev -> {
+            MailPrefs tmp = new MailPrefs(
+                    tfHost.getText(),
+                    Integer.parseInt(tfPort.getText()),
+                    cbSSL.isSelected(),
+                    tfUser.getText(),
+                    tfPwd.getText(),
+                    cbProv.getValue().provider(),
+                    prefsBox[0].oauthClient(),
+                    prefsBox[0].oauthRefresh(),
+                    prefsBox[0].oauthExpiry(),
+                    tfFrom.getText(),
+                    tfCopy.getText(),
+                    spDelay.getValue(),
+                    taSubjP.getText(),
+                    taBodyP.getText(),
+                    taSubjS.getText(),
+                    taBodyS.getText()
+            );
+            TextInputDialog td = new TextInputDialog(tmp.from());
+            td.setTitle("Envoi de test");
+            td.setHeaderText("Destinataire");
+            ThemeManager.apply(td);
+            td.showAndWait().ifPresent(addr -> {
+                try {
+                    Mailer.send(tmp, addr, "Test", "Ceci est un message de test.");
+                    Alert a = new Alert(Alert.AlertType.INFORMATION, "E-mail envoyé", ButtonType.OK);
+                    ThemeManager.apply(a);
+                    a.showAndWait();
+                } catch (Exception ex) {
+                    Alert a = new Alert(Alert.AlertType.ERROR, ex.getMessage(), ButtonType.OK);
+                    ThemeManager.apply(a);
+                    a.showAndWait();
+                }
+            });
+        });
+
+        setResultConverter(bt -> {
+            if (bt == ButtonType.OK) {
+                return new MailPrefs(
+                        tfHost.getText(),
+                        Integer.parseInt(tfPort.getText()),
+                        cbSSL.isSelected(),
+                        tfUser.getText(),
+                        tfPwd.getText(),
+                        cbProv.getValue().provider(),
+                        prefsBox[0].oauthClient(),
+                        prefsBox[0].oauthRefresh(),
+                        prefsBox[0].oauthExpiry(),
+                        tfFrom.getText(),
+                        tfCopy.getText(),
+                        spDelay.getValue(),
+                        taSubjP.getText(),
+                        taBodyP.getText(),
+                        taSubjS.getText(),
+                        taBodyS.getText()
+                );
+            }
+            return null;
+        });
+    }
+
+    /** Open the dialog and save the preferences if confirmed. */
+    public static void open(Stage owner, MailPrefsDAO dao) {
+        MailQuickSetupDialog d = new MailQuickSetupDialog(dao.load(), dao);
+        ThemeManager.apply(d);
+        d.initOwner(owner);
+        d.setHeaderText("Configurer le serveur SMTP, modèles et délai.");
+        d.showAndWait().ifPresent(dao::save);
+    }
+}

--- a/src/main/java/org/example/gui/MainView.java
+++ b/src/main/java/org/example/gui/MainView.java
@@ -21,7 +21,7 @@ import org.example.pdf.PDF;
 import org.example.mail.Mailer;
 import org.example.mail.MailPrefs;
 import org.example.dao.MailPrefsDAO;
-import org.example.gui.MailSettingsDialog;
+import org.example.gui.MailQuickSetupDialog;
 import org.example.gui.ThemeManager;
 
 import java.nio.file.Path;
@@ -239,7 +239,7 @@ public class MainView {
             }
         });
 
-        bPrefsMail.setOnAction(e -> MailSettingsDialog.open(stage, mailPrefsDao));
+        bPrefsMail.setOnAction(e -> MailQuickSetupDialog.open(stage, mailPrefsDao));
         HBox hb = new HBox(16, bAdd, bEdit, bDel, bService, bHist, bFact, bPDF, bPDFAll, bPrefsMail);
         hb.setPadding(new Insets(10));
         hb.setAlignment(Pos.CENTER_LEFT);

--- a/src/main/java/org/example/mail/SmtpPreset.java
+++ b/src/main/java/org/example/mail/SmtpPreset.java
@@ -1,0 +1,35 @@
+package org.example.mail;
+
+/** Simple data holder for SMTP provider presets. */
+public record SmtpPreset(
+        String provider,
+        String label,
+        String host,
+        int port,
+        boolean ssl,
+        boolean oauth
+) {
+    /** Display label in combo boxes. */
+    @Override public String toString() { return label; }
+
+    /** Known presets. Index 0 is a generic custom configuration. */
+    public static final SmtpPreset[] PRESETS = {
+            new SmtpPreset("custom", "Personnalisé",
+                    "smtp.example.com", 465, true, false),
+            new SmtpPreset("gmail", "Gmail (OAuth)",
+                    "smtp.gmail.com", 587, false, true),
+            new SmtpPreset("outlook", "Outlook / Office365",
+                    "smtp.office365.com", 587, false, false)
+    };
+
+    /** Find a preset by provider id, ignoring case. */
+    public static SmtpPreset byProvider(String provider) {
+        if (provider == null) return null;
+        for (SmtpPreset p : PRESETS) {
+            if (p.provider.equalsIgnoreCase(provider)) {
+                return p;
+            }
+        }
+        return null;
+    }
+}

--- a/src/test/java/org/example/gui/MailQuickSetupDialogTest.java
+++ b/src/test/java/org/example/gui/MailQuickSetupDialogTest.java
@@ -1,0 +1,78 @@
+package org.example.gui;
+
+import javafx.application.Platform;
+import javafx.embed.swing.JFXPanel;
+import javafx.scene.control.ButtonType;
+import org.example.dao.MailPrefsDAO;
+import org.example.mail.MailPrefs;
+import org.junit.jupiter.api.*;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MailQuickSetupDialogTest {
+    private Connection conn;
+    private MailPrefsDAO dao;
+
+    @BeforeAll
+    static void initJfx() {
+        new JFXPanel();
+    }
+
+    @BeforeEach
+    void setup() throws Exception {
+        conn = DriverManager.getConnection("jdbc:sqlite::memory:");
+        try (Statement st = conn.createStatement()) {
+            st.executeUpdate("""
+                CREATE TABLE mail_prefs (
+                    id INTEGER PRIMARY KEY CHECK(id=1),
+                    host TEXT NOT NULL,
+                    port INTEGER NOT NULL,
+                    ssl INTEGER NOT NULL DEFAULT 1,
+                    user TEXT,
+                    pwd TEXT,
+                    provider TEXT,
+                    oauth_client TEXT,
+                    oauth_refresh TEXT,
+                    oauth_expiry INTEGER,
+                    from_addr TEXT NOT NULL,
+                    copy_to_self TEXT,
+                    delay_hours INTEGER NOT NULL DEFAULT 48,
+                    subj_tpl_presta TEXT NOT NULL,
+                    body_tpl_presta TEXT NOT NULL,
+                    subj_tpl_self TEXT NOT NULL,
+                    body_tpl_self TEXT NOT NULL
+                )
+            """);
+        }
+        dao = new MailPrefsDAO(conn);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        conn.close();
+    }
+
+    @Test
+    void testDialogResultPersists() throws Exception {
+        MailPrefs initial = MailPrefs.defaultValues();
+        dao.save(initial);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            MailQuickSetupDialog d = new MailQuickSetupDialog(initial, dao);
+            MailPrefs res = d.getResultConverter().call(ButtonType.OK);
+            dao.save(res);
+            latch.countDown();
+        });
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+
+        MailPrefs stored = dao.load();
+        assertEquals(initial.host(), stored.host());
+    }
+}

--- a/src/test/java/org/example/mail/SmtpPresetTest.java
+++ b/src/test/java/org/example/mail/SmtpPresetTest.java
@@ -1,0 +1,15 @@
+package org.example.mail;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SmtpPresetTest {
+    @Test
+    void testByProvider() {
+        SmtpPreset gmail = SmtpPreset.byProvider("gmail");
+        assertNotNull(gmail);
+        assertEquals("gmail", gmail.provider());
+        assertEquals("smtp.gmail.com", gmail.host());
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `SmtpPreset` with default presets and lookup utility
- add `MailQuickSetupDialog` to configure mail using provider presets
- switch main view to use the new dialog
- add unit tests for preset lookup and dialog persistence

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686af0ac0f94832e84d68774d15f1b85