### PR TITLE
Add preset support for mail preferences

### DIFF
--- a/src/main/java/org/example/dao/MailPrefsDAO.java
+++ b/src/main/java/org/example/dao/MailPrefsDAO.java
@@ -1,6 +1,7 @@
 package org.example.dao;
 
 import org.example.mail.MailPrefs;
+import org.example.mail.SmtpPreset;
 
 import java.sql.*;
 
@@ -11,7 +12,7 @@ public class MailPrefsDAO {
     public MailPrefs load(){
         try (Statement st = c.createStatement()){
             ResultSet rs = st.executeQuery("SELECT * FROM mail_prefs WHERE id=1");
-            if(!rs.next()) return MailPrefs.defaultValues();
+            if(!rs.next()) return MailPrefs.fromPreset(SmtpPreset.PRESETS[0]);
             return MailPrefs.fromRS(rs);
         } catch(SQLException e){ throw new RuntimeException(e);}    }
     public void save(MailPrefs p){

--- a/src/main/java/org/example/gui/MailQuickSetupDialog.java
+++ b/src/main/java/org/example/gui/MailQuickSetupDialog.java
@@ -128,13 +128,14 @@ public class MailQuickSetupDialog extends Dialog<MailPrefs> {
         ok.disableProperty().bind(invalid);
 
         bTest.setOnAction(ev -> {
+            MailPrefs base = MailPrefs.fromPreset(cbProv.getValue());
             MailPrefs tmp = new MailPrefs(
                     tfHost.getText(),
                     Integer.parseInt(tfPort.getText()),
                     cbSSL.isSelected(),
                     tfUser.getText(),
                     tfPwd.getText(),
-                    cbProv.getValue().provider(),
+                    base.provider(),
                     prefsBox[0].oauthClient(),
                     prefsBox[0].oauthRefresh(),
                     prefsBox[0].oauthExpiry(),
@@ -166,13 +167,14 @@ public class MailQuickSetupDialog extends Dialog<MailPrefs> {
 
         setResultConverter(bt -> {
             if (bt == ButtonType.OK) {
+                MailPrefs base = MailPrefs.fromPreset(cbProv.getValue());
                 return new MailPrefs(
                         tfHost.getText(),
                         Integer.parseInt(tfPort.getText()),
                         cbSSL.isSelected(),
                         tfUser.getText(),
                         tfPwd.getText(),
-                        cbProv.getValue().provider(),
+                        base.provider(),
                         prefsBox[0].oauthClient(),
                         prefsBox[0].oauthRefresh(),
                         prefsBox[0].oauthExpiry(),

--- a/src/main/java/org/example/mail/MailPrefs.java
+++ b/src/main/java/org/example/mail/MailPrefs.java
@@ -36,6 +36,23 @@ public record MailPrefs(
         );
     }
 
+    /**
+     * Create a new configuration from an SMTP preset. Message templates and
+     * delay use the default values while all user related fields are empty.
+     */
+    public static MailPrefs fromPreset(SmtpPreset pre) {
+        MailPrefs def = defaultValues();
+        return new MailPrefs(
+                pre.host(), pre.port(), pre.ssl(),
+                "", "",
+                pre.provider(), "", "", 0L,
+                "", "",
+                def.delayHours(),
+                def.subjPresta(), def.bodyPresta(),
+                def.subjSelf(), def.bodySelf()
+        );
+    }
+
     public static MailPrefs fromRS(ResultSet rs) throws SQLException {
         String provider = rs.getString("provider");
         if(provider == null) provider = "";

--- a/src/test/java/org/example/dao/MailPrefsDAOTest.java
+++ b/src/test/java/org/example/dao/MailPrefsDAOTest.java
@@ -1,6 +1,7 @@
 package org.example.dao;
 
 import org.example.mail.MailPrefs;
+import org.example.mail.SmtpPreset;
 import org.junit.jupiter.api.*;
 
 import java.sql.*;
@@ -46,10 +47,11 @@ public class MailPrefsDAOTest {
     }
 
     @Test
-    void testLoadDefaultWhenEmpty() {
+    void testLoadPresetWhenEmpty() {
         MailPrefs prefs = dao.load();
-        assertEquals(MailPrefs.defaultValues(), prefs);
-        assertEquals("", prefs.provider());
+        MailPrefs expected = MailPrefs.fromPreset(SmtpPreset.PRESETS[0]);
+        assertEquals(expected, prefs);
+        assertEquals("custom", prefs.provider());
         assertEquals("", prefs.oauthClient());
         assertEquals("", prefs.oauthRefresh());
         assertEquals(0L, prefs.oauthExpiry());


### PR DESCRIPTION
## Summary
- add `MailPrefs.fromPreset` to build defaults from `SmtpPreset`
- use preset when `MailPrefsDAO.load` returns empty result
- create mail prefs from preset in quick setup dialog
- update DAO unit test for new behaviour

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bd3f0d8d0832e8a302aab632aea3e