### PR TITLE
Update mail OAuth handling

### DIFF
--- a/src/test/java/org/example/mail/MailerTest.java
+++ b/src/test/java/org/example/mail/MailerTest.java
@@ -1,0 +1,34 @@
+package org.example.mail;
+
+import jakarta.mail.Session;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MailerTest {
+    @Test
+    public void outlookSessionUsesXoauth2() throws Exception {
+        SmtpPreset preset = SmtpPreset.byProvider("outlook");
+        MailPrefs cfg = MailPrefs.fromPreset(preset);
+        // minimal user info
+        cfg = new MailPrefs(
+                cfg.host(), cfg.port(), cfg.ssl(),
+                "user@example.com", "",
+                "outlook", "", "", 0L,
+                "from@example.com", "", cfg.delayHours(),
+                cfg.subjPresta(), cfg.bodyPresta(),
+                cfg.subjSelf(), cfg.bodySelf()
+        );
+
+        Method m = Mailer.class.getDeclaredMethod("makeSessionOAuth", MailPrefs.class, String.class);
+        m.setAccessible(true);
+        Session session = (Session) m.invoke(null, cfg, "testToken");
+
+        Properties p = session.getProperties();
+        assertEquals("true", p.getProperty("mail.smtp.sasl.enable"));
+        assertEquals("XOAUTH2", p.getProperty("mail.smtp.auth.mechanisms"));
+    }
+}


### PR DESCRIPTION
## Summary
- dispatch OAuth logic in Mailer based on provider
- expose XOAUTH2 SASL properties for OAuth sessions
- test OAuth session creation for Outlook

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bd57a22a4832e98f932f14d7e2867