### PR TITLE
Fix JavaFX plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <javafx.version>21.0.2</javafx.version>
         <junit.jupiter.version>5.10.1</junit.jupiter.version>
         <surefire.plugin.version>3.2.2</surefire.plugin.version>
-        <javafx.maven.plugin.version>0.0.15</javafx.maven.plugin.version>
+        <javafx.maven.plugin.version>0.0.8</javafx.maven.plugin.version>
 
     </properties>
 


### PR DESCRIPTION
## Summary
- fix the JavaFX Maven plugin version to 0.0.8

## Testing
- `mvn test` *(fails: `mvn` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c2440af5c832eb6282677464220f4