### PR TITLE
Fix SQLite connection handling

### DIFF
--- a/src/main/java/org/example/MainApp.java
+++ b/src/main/java/org/example/MainApp.java
@@ -30,7 +30,7 @@ public class MainApp extends Application {
     @Override
     public void start(Stage primaryStage) {
         dao = new DB(DB_FILE);
-        mailPrefsDao = new MailPrefsDAO(dao.getConnection());
+        mailPrefsDao = new MailPrefsDAO(dao);
         view = new MainView(primaryStage, dao, mailPrefsDao);
         primaryStage.setTitle("Gestion des Prestataires");
         Scene sc = new Scene(view.getRoot(), 920, 600);

--- a/src/main/java/org/example/dao/ConnectionProvider.java
+++ b/src/main/java/org/example/dao/ConnectionProvider.java
@@ -1,0 +1,9 @@
+package org.example.dao;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface ConnectionProvider {
+    Connection getConnection() throws SQLException;
+}

--- a/src/main/java/org/example/dao/MailPrefsDAO.java
+++ b/src/main/java/org/example/dao/MailPrefsDAO.java
@@ -6,11 +6,11 @@ import org.example.mail.SmtpPreset;
 import java.sql.*;
 
 public class MailPrefsDAO {
-    private final Connection c;
-    public MailPrefsDAO(Connection c){ this.c = c; }
+    private final ConnectionProvider ds;
+    public MailPrefsDAO(ConnectionProvider ds){ this.ds = ds; }
 
     public MailPrefs load(){
-        try (Statement st = c.createStatement()){
+        try (Connection c = ds.getConnection(); Statement st = c.createStatement()){
             ResultSet rs = st.executeQuery("SELECT * FROM mail_prefs WHERE id=1");
             if(!rs.next()) return MailPrefs.fromPreset(SmtpPreset.PRESETS[0]);
             return MailPrefs.fromRS(rs);
@@ -31,7 +31,7 @@ public class MailPrefsDAO {
               subj_tpl_presta=excluded.subj_tpl_presta,body_tpl_presta=excluded.body_tpl_presta,
               subj_tpl_self=excluded.subj_tpl_self,body_tpl_self=excluded.body_tpl_self
         """;
-        try (PreparedStatement ps = c.prepareStatement(sql)){
+        try (Connection c = ds.getConnection(); PreparedStatement ps = c.prepareStatement(sql)){
             p.bind(ps);
             ps.executeUpdate();
         }catch(SQLException e){ throw new RuntimeException(e);}    }

--- a/src/main/java/org/example/gui/MainView.java
+++ b/src/main/java/org/example/gui/MainView.java
@@ -60,7 +60,7 @@ public class MainView {
      * explicitly provide a {@link MailPrefsDAO} instance.
      */
     public MainView(Stage stage, DB dao) {
-        this(stage, dao, new MailPrefsDAO(dao.getConnection()));
+        this(stage, dao, new MailPrefsDAO(dao));
     }
 
     public Parent getRoot() {

--- a/src/test/java/org/example/dao/DBTest.java
+++ b/src/test/java/org/example/dao/DBTest.java
@@ -19,7 +19,7 @@ public class DBTest {
 
     @BeforeEach
     void setUp() {
-        db = new DB(":memory:");
+        db = new DB("file:memdb1?mode=memory&cache=shared");
     }
 
     @AfterEach

--- a/src/test/java/org/example/dao/MailPrefsDAOTest.java
+++ b/src/test/java/org/example/dao/MailPrefsDAOTest.java
@@ -9,13 +9,13 @@ import java.sql.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class MailPrefsDAOTest {
-    private Connection conn;
+    private String url;
     private MailPrefsDAO dao;
 
     @BeforeEach
     void setUp() throws Exception {
-        conn = DriverManager.getConnection("jdbc:sqlite::memory:");
-        try (Statement st = conn.createStatement()) {
+        url = "file:prefsdb?mode=memory&cache=shared";
+        try (Connection conn = DB.newConnection(url); Statement st = conn.createStatement()) {
             st.executeUpdate("""
                 CREATE TABLE mail_prefs (
                     id INTEGER PRIMARY KEY CHECK(id=1),
@@ -39,13 +39,9 @@ public class MailPrefsDAOTest {
                 )
             """);
         }
-        dao = new MailPrefsDAO(conn);
+        dao = new MailPrefsDAO(() -> DB.newConnection(url));
     }
 
-    @AfterEach
-    void tearDown() throws Exception {
-        conn.close();
-    }
 
     @Test
     void testLoadPresetWhenEmpty() {

--- a/src/test/java/org/example/gui/MailQuickSetupDialogAutoTest.java
+++ b/src/test/java/org/example/gui/MailQuickSetupDialogAutoTest.java
@@ -3,13 +3,13 @@ package org.example.gui;
 import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
 import org.example.dao.MailPrefsDAO;
+import org.example.dao.DB;
 import org.example.mail.MailPrefs;
 import org.example.mail.autodetect.AutoConfigProvider;
 import org.example.mail.autodetect.AutoConfigResult;
 import org.junit.jupiter.api.*;
 
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.Statement;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class MailQuickSetupDialogAutoTest {
-    private Connection conn;
+    private String url;
     private MailPrefsDAO dao;
 
     @BeforeAll
@@ -25,8 +25,8 @@ public class MailQuickSetupDialogAutoTest {
 
     @BeforeEach
     void setup() throws Exception {
-        conn = DriverManager.getConnection("jdbc:sqlite::memory:");
-        try (Statement st = conn.createStatement()) {
+        url = "file:prefsauto?mode=memory&cache=shared";
+        try (Connection conn = DB.newConnection(url); Statement st = conn.createStatement()) {
             st.executeUpdate("""
                 CREATE TABLE mail_prefs (
                     id INTEGER PRIMARY KEY CHECK(id=1),
@@ -50,11 +50,9 @@ public class MailQuickSetupDialogAutoTest {
                 )
             """);
         }
-        dao = new MailPrefsDAO(conn);
+        dao = new MailPrefsDAO(() -> DB.newConnection(url));
     }
 
-    @AfterEach
-    void tearDown() throws Exception { conn.close(); }
 
     @Test
     void testAutoDiscoveryPopulatesFields() throws Exception {

--- a/src/test/java/org/example/gui/MailQuickSetupDialogTest.java
+++ b/src/test/java/org/example/gui/MailQuickSetupDialogTest.java
@@ -4,11 +4,11 @@ import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
 import javafx.scene.control.ButtonType;
 import org.example.dao.MailPrefsDAO;
+import org.example.dao.DB;
 import org.example.mail.MailPrefs;
 import org.junit.jupiter.api.*;
 
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.Statement;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class MailQuickSetupDialogTest {
-    private Connection conn;
+    private String url;
     private MailPrefsDAO dao;
 
     @BeforeAll
@@ -26,8 +26,8 @@ public class MailQuickSetupDialogTest {
 
     @BeforeEach
     void setup() throws Exception {
-        conn = DriverManager.getConnection("jdbc:sqlite::memory:");
-        try (Statement st = conn.createStatement()) {
+        url = "file:prefsdlg?mode=memory&cache=shared";
+        try (Connection conn = DB.newConnection(url); Statement st = conn.createStatement()) {
             st.executeUpdate("""
                 CREATE TABLE mail_prefs (
                     id INTEGER PRIMARY KEY CHECK(id=1),
@@ -51,12 +51,7 @@ public class MailQuickSetupDialogTest {
                 )
             """);
         }
-        dao = new MailPrefsDAO(conn);
-    }
-
-    @AfterEach
-    void tearDown() throws Exception {
-        conn.close();
+        dao = new MailPrefsDAO(() -> DB.newConnection(url));
     }
 
     @Test

--- a/src/test/java/org/example/mail/GoogleAuthServiceTest.java
+++ b/src/test/java/org/example/mail/GoogleAuthServiceTest.java
@@ -1,6 +1,7 @@
 package org.example.mail;
 
 import org.example.dao.MailPrefsDAO;
+import org.example.dao.DB;
 import org.junit.jupiter.api.*;
 
 import java.lang.reflect.Field;
@@ -10,7 +11,6 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpClient.Version;
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.Statement;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -18,13 +18,13 @@ import java.util.concurrent.CompletableFuture;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class GoogleAuthServiceTest {
-    private Connection conn;
+    private String url;
     private MailPrefsDAO dao;
 
     @BeforeEach
     void setUp() throws Exception {
-        conn = DriverManager.getConnection("jdbc:sqlite::memory:");
-        try (Statement st = conn.createStatement()) {
+        url = "file:google?mode=memory&cache=shared";
+        try (Connection conn = DB.newConnection(url); Statement st = conn.createStatement()) {
             st.executeUpdate("""
                 CREATE TABLE mail_prefs (
                     id INTEGER PRIMARY KEY CHECK(id=1),
@@ -48,7 +48,7 @@ public class GoogleAuthServiceTest {
                 )
             """);
         }
-        dao = new MailPrefsDAO(conn);
+        dao = new MailPrefsDAO(() -> DB.newConnection(url));
         MailPrefs prefs = new MailPrefs(
                 "smtp.gmail.com", 465, true,
                 "user", "pwd",
@@ -59,10 +59,7 @@ public class GoogleAuthServiceTest {
         dao.save(prefs);
     }
 
-    @AfterEach
-    void tearDown() throws Exception {
-        conn.close();
-    }
+
 
     @Test
     void testTokenRefresh() throws Exception {


### PR DESCRIPTION
## Summary
- create `ConnectionProvider` interface
- open SQLite connections in `FULLMUTEX` mode
- return a new connection for every DAO call
- update `MailPrefsDAO` and GUI to use the provider
- adapt unit tests for the new connection strategy

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686d2d4d2748832eb81639c3e8353933