### PR TITLE
Use random port for OAuth receiver

### DIFF
--- a/src/main/java/org/example/mail/GmailOAuth2Service.java
+++ b/src/main/java/org/example/mail/GmailOAuth2Service.java
@@ -78,8 +78,9 @@ public final class GmailOAuth2Service {
                 .build();
 
         LocalServerReceiver receiver = new LocalServerReceiver.Builder()
-                .setPort(8888)                 // ⇢ http://localhost:8888/Callback
+                .setPort(0)                    // 0 = port aléatoire
                 .build();
+        String redirect = receiver.getRedirectUri();
 
         Credential cred = new AuthorizationCodeInstalledApp(flow, receiver)
                 .authorize("user");


### PR DESCRIPTION
## Summary
- handle case where port 8888 is taken
- use LocalServerReceiver with a random system port
- retrieve redirect URI

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d3d8f7f3c832e978a4d8a3bb44b2c