### PR TITLE
Fix tests by exiting JavaFX Platform

### DIFF
--- a/src/test/java/org/example/gui/MailQuickSetupDialogAutoTest.java
+++ b/src/test/java/org/example/gui/MailQuickSetupDialogAutoTest.java
@@ -23,6 +23,9 @@ public class MailQuickSetupDialogAutoTest {
     @BeforeAll
     static void initJfx() { new JFXPanel(); }
 
+    @AfterAll
+    static void shutdown() { Platform.exit(); }
+
     @BeforeEach
     void setup() throws Exception {
         url = "file:prefsauto?mode=memory&cache=shared";

--- a/src/test/java/org/example/gui/MailQuickSetupDialogTest.java
+++ b/src/test/java/org/example/gui/MailQuickSetupDialogTest.java
@@ -24,6 +24,9 @@ public class MailQuickSetupDialogTest {
         new JFXPanel();
     }
 
+    @AfterAll
+    static void shutdown() { Platform.exit(); }
+
     @BeforeEach
     void setup() throws Exception {
         url = "file:prefsdlg?mode=memory&cache=shared";


### PR DESCRIPTION
## Summary
- add a shutdown step in MailQuickSetupDialogAutoTest
- add a shutdown step in MailQuickSetupDialogTest

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d491abe58832e8bb4ff27389515ac