### PR TITLE
Fix build by removing unused Gmail API dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,12 +98,6 @@
             <version>1.43.3</version>
         </dependency>
 
-        <!-- Google Gmail API client -->
-        <dependency>
-            <groupId>com.google.apis</groupId>
-            <artifactId>google-api-services-gmail</artifactId>
-            <version>v1-rev20231115-2.0.0</version>
-        </dependency>
         <!-- JUnit 5 for tests -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- remove `google-api-services-gmail` dependency

The previous version referenced `v1-rev20231115-2.0.0` which was never published. Since the project does not use the Gmail API, the dependency is unnecessary.

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686d57bd59a8832ea9c068b8d3df28b2