### PR TITLE
Fix Maven plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <javafx.version>21.0.2</javafx.version>
         <junit.jupiter.version>5.10.1</junit.jupiter.version>
         <surefire.plugin.version>3.2.2</surefire.plugin.version>
-        <javafx.maven.plugin.version>0.0.15</javafx.maven.plugin.version>
+        <javafx.maven.plugin.version>0.0.8</javafx.maven.plugin.version>
 
     </properties>
 


### PR DESCRIPTION
## Summary
- use published javafx-maven-plugin version 0.0.8

## Testing
- `mvn -q -DskipTests=false test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d5f2fd84c832eac4381a5529d219a