### PR TITLE
Fix plugin error for jlinkZip

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,11 +113,22 @@
             <plugin>
                 <groupId>org.openjfx</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>
-                <version>${javafx.maven.plugin.version}</version>
+                <version>${javafx.maven.plugin.version}</version><!-- 0.0.8 ou + -->
                 <configuration>
                     <mainClass>org.example.MainApp</mainClass>
-                    <jlinkZip>false</jlinkZip>
+                    <launcher>MonApp</launcher>
+                    <jlinkZip>true</jlinkZip>        <!-- option reconnue à partir de 0.0.6 -->
                 </configuration>
+
+                <!-- si vous voulez que jlink s’exécute à chaque build -->
+                <executions>
+                    <execution>
+                        <id>create-runtime-image</id>
+                        <goals>
+                            <goal>jlink</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary
- update the javafx-maven-plugin configuration to a working example

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d643ef6c4832ea7769b109a2c3074