### PR TITLE
Fix build warnings and jlink config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,12 +17,10 @@
 
     <properties>
         <!-- Java 17 = LTS, compatible avec JavaFX 21 -->
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <javafx.version>21.0.2</javafx.version>
         <junit.jupiter.version>5.10.1</junit.jupiter.version>
         <surefire.plugin.version>3.2.2</surefire.plugin.version>
-        <javafx.maven.plugin.version>0.0.8</javafx.maven.plugin.version>
 
     </properties>
 
@@ -113,22 +111,29 @@
             <plugin>
                 <groupId>org.openjfx</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>
-                <version>${javafx.maven.plugin.version}</version><!-- 0.0.8 ou + -->
+                <version>0.0.8</version> <!-- 0.1.0 fonctionne tout aussi bien -->
                 <configuration>
                     <mainClass>org.example.MainApp</mainClass>
-                    <launcher>MonApp</launcher>
-                    <jlinkZip>true</jlinkZip>        <!-- option reconnue à partir de 0.0.6 -->
                 </configuration>
-
-                <!-- si vous voulez que jlink s’exécute à chaque build -->
                 <executions>
                     <execution>
                         <id>create-runtime-image</id>
                         <goals>
                             <goal>jlink</goal>
                         </goals>
+                        <configuration>
+                            <jlinkZip>true</jlinkZip>
+                            <launcher>MonApp</launcher>
+                        </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <release>17</release>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary
- clean Maven build config
- place jlinkZip under the jlink execution
- use `maven-compiler-plugin` with Java release 17

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d6cc022b0832eb28543fb537bc44b