### PR TITLE
Move sqlite dependency to end

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,12 +54,6 @@
             <version>${javafx.version}</version>
         </dependency>
 
-        <!-- SQLite JDBC driver (Apache 2) -->
-        <dependency>
-            <groupId>org.xerial</groupId>
-            <artifactId>sqlite-jdbc</artifactId>
-            <version>3.45.2.0</version>
-        </dependency>
 
         <!-- OpenPDF (fork LGPL d’iText 4) -->
         <dependency>
@@ -94,6 +88,13 @@
             <groupId>com.google.http-client</groupId>
             <artifactId>google-http-client-jackson2</artifactId>
             <version>1.43.3</version>
+        </dependency>
+
+        <!-- SQLite JDBC driver (Apache 2) -->
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.45.2.0</version>
         </dependency>
 
         <!-- JUnit 5 for tests -->


### PR DESCRIPTION
## Summary
- relocate `sqlite-jdbc` dependency to the end of the dependency list to override transitive pulls

## Testing
- `mvn -q dependency:tree -Dincludes=org.xerial:sqlite-jdbc` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d6fcc6d9c832eb52580f246936a03