### PR TITLE
Prevent NPE on null contract date

### DIFF
--- a/src/main/java/org/example/dao/DB.java
+++ b/src/main/java/org/example/dao/DB.java
@@ -14,6 +14,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class DB implements AutoCloseable, ConnectionProvider {
     private static final DateTimeFormatter DATE_FR = DateTimeFormatter.ofPattern("dd/MM/yyyy");
@@ -397,7 +398,7 @@ public class DB implements AutoCloseable, ConnectionProvider {
         ps.setString(4, p.getEmail());
         ps.setInt(5, p.getNote());
         ps.setString(6, p.getFacturation());
-        String raw = p.getDateContrat().trim();
+        String raw = Objects.toString(p.getDateContrat(), "").trim();
         if (raw.isEmpty()) ps.setNull(7, Types.VARCHAR);
         else ps.setString(7, LocalDate.parse(raw, DATE_FR).format(DATE_DB));
     }

--- a/src/test/java/org/example/dao/DBTest.java
+++ b/src/test/java/org/example/dao/DBTest.java
@@ -86,4 +86,12 @@ public class DBTest {
         assertTrue(all.get(0).isPaye());
         assertNotNull(all.get(0).getDatePaiement());
     }
+
+    @Test
+    void testAddWithNullDateContrat() {
+        Prestataire p = new Prestataire(0, "Nom", "S", "0", "a@b.com", 50, "F", null);
+        db.add(p);
+        Prestataire stored = db.list("").get(0);
+        assertEquals("", stored.getDateContrat());
+    }
 }


### PR DESCRIPTION
## Summary
- avoid NullPointerException when `dateContrat` is null
- test adding a Prestataire with a null contract date

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc139be74832e80c14b31fce3cfdd