### PR TITLE
Use single connection pool for database access

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,13 @@
             <version>3.45.2.0</version>
         </dependency>
 
+        <!-- Lightweight JDBC connection pool -->
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>5.1.0</version>
+        </dependency>
+
         <!-- JUnit 5 for tests -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary
- add HikariCP dependency
- manage a pooled DataSource in `DB`
- open pooled connections for all database operations

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686fd5b20af8832ea104a1e2887c4986