### PR TITLE
Fix email validation regex

### DIFF
--- a/src/main/java/org/example/gui/MainView.java
+++ b/src/main/java/org/example/gui/MainView.java
@@ -258,7 +258,7 @@ public class MainView {
         gp.setPadding(new Insets(12));
         String[] lab = {"Nom","Société","Téléphone","Email","Note (0-100)","Facturation","Date contrat (dd/MM/yyyy)"};
         TextField[] fields = new TextField[lab.length];
-        Pattern mailRegex = Pattern.compile("[^@]+@[^@]+\\.[^@]+");
+        Pattern mailRegex = Pattern.compile("^[^@\\s]+@[^@\\s]+\\.[^@\\s]{2,}$");
 
         for (int i = 0; i < lab.length; i++) {
             gp.add(new Label(lab[i] + "  :"), 0, i);


### PR DESCRIPTION
## Summary
- use a stricter regex for email addresses in the provider editor

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686fd76a8a7c832ea866945dd7852cb4