### PR TITLE
Fix GUI executor usage

### DIFF
--- a/src/main/java/org/example/gui/MainView.java
+++ b/src/main/java/org/example/gui/MainView.java
@@ -40,7 +40,9 @@ public class MainView {
     private final DB dao;
     private final MailPrefsDAO mailPrefsDao;
 
-    private final ExecutorService executor = Executors.newSingleThreadExecutor(r -> new Thread(r, "gui-bg"));
+    // Utilise un pool de travail pour éviter de bloquer l'interface
+    // lorsqu'une tâche prend du temps (I/O, PDF, DAO...).
+    private final ExecutorService executor = Executors.newWorkStealingPool();
 
     private final TableView<Prestataire> table = new TableView<>();
     private final TextField search = new TextField();


### PR DESCRIPTION
## Summary
- use `Executors.newWorkStealingPool()` in `MainView` to avoid blocking the UI when background operations are slow

## Testing
- `mvn test` *(fails: `mvn` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fdbb7d260832ea1b2ee1e5600cbd3