### PR TITLE
Validate OAuth client info

### DIFF
--- a/src/main/java/org/example/gui/MailQuickSetupDialog.java
+++ b/src/main/java/org/example/gui/MailQuickSetupDialog.java
@@ -108,6 +108,14 @@ public class MailQuickSetupDialog extends Dialog<MailPrefs> {
         bOAuth.getStyleClass().add("accent");
         bOAuth.setVisible(false);
         bOAuth.setOnAction(ev -> {
+            if (!tfClient.getText().contains(":")) {
+                Alert a = new Alert(Alert.AlertType.ERROR,
+                        "Les champs clientId et clientSecret doivent être renseignés",
+                        ButtonType.OK);
+                ThemeManager.apply(a);
+                a.showAndWait();
+                return;
+            }
             try {
                 MailPrefs base = prefsBox[0];
                 MailPrefs tmp = new MailPrefs(
@@ -256,6 +264,7 @@ public class MailQuickSetupDialog extends Dialog<MailPrefs> {
                 .or(rbOauth2.selectedProperty().and(oauthInvalid));
         Button ok = (Button) getDialogPane().lookupButton(ButtonType.OK);
         ok.disableProperty().bind(invalid);
+        bOAuth.disableProperty().bind(oauthInvalid);
 
         bTest.setOnAction(ev -> {
             MailPrefs base = MailPrefs.fromPreset(cbProv.getValue());


### PR DESCRIPTION
## Summary
- verify OAuth client input before launching authorization
- bind Google login button to same validation rule

## Testing
- `mvn -q -e -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870210eeae4832ea53c94bc760ce41f