### PR TITLE
Add OAuth client split helper

### DIFF
--- a/src/main/java/org/example/mail/GmailOAuth2Service.java
+++ b/src/main/java/org/example/mail/GmailOAuth2Service.java
@@ -42,8 +42,16 @@ public final class GmailOAuth2Service {
         this.prefs = prefs;
     }
 
-    private String clientId()  { return prefs.oauthClient().split(":",2)[0]; }
-    private String clientSec() { return prefs.oauthClient().split(":",2)[1]; }
+    private String[] client() {
+        String[] parts = prefs.oauthClient().split(":", 2);
+        if (parts.length != 2 || parts[0].isBlank() || parts[1].isBlank()) {
+            throw new IllegalStateException("OAuth client id/secret missing");
+        }
+        return parts;
+    }
+
+    private String clientId()  { return client()[0]; }
+    private String clientSec() { return client()[1]; }
 
     private static final List<String> SCOPES = List.of("https://mail.google.com/");
 


### PR DESCRIPTION
## Summary
- centralize OAuth client parsing in GmailOAuth2Service
- use new client() helper to read client id and secret

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687021e5d4b8832e84786134d918c727