### PR TITLE
Fix OAuth client retrieval in MicrosoftAuthService

### DIFF
--- a/src/main/java/org/example/mail/MicrosoftAuthService.java
+++ b/src/main/java/org/example/mail/MicrosoftAuthService.java
@@ -35,8 +35,16 @@ public class MicrosoftAuthService implements OAuthService {
         this.prefs = prefs;
     }
 
-    private String clientId()  { return prefs.oauthClient().split(":",2)[0]; }
-    private String clientSec() { return prefs.oauthClient().split(":",2)[1]; }
+    private String[] client() {
+        String[] parts = prefs.oauthClient().split(":", 2);
+        if (parts.length != 2 || parts[0].isBlank() || parts[1].isBlank()) {
+            throw new IllegalStateException("OAuth client id/secret missing");
+        }
+        return parts;
+    }
+
+    private String clientId()  { return client()[0]; }
+    private String clientSec() { return client()[1]; }
 
     @Override
     public synchronized void interactiveAuth() {


### PR DESCRIPTION
## Summary
- add `client()` helper in `MicrosoftAuthService`
- use helper in `clientId()` and `clientSec()` for clearer error handling

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870255bd058832e90e6715de2d4b3e2