### PR TITLE
Fix Gmail OAuth dialog and validate recipient

### DIFF
--- a/src/main/java/org/example/MainApp.java
+++ b/src/main/java/org/example/MainApp.java
@@ -54,6 +54,10 @@ public class MainApp extends Application {
         // ② rappels manuels (table rappels)
         dao.rappelsÀEnvoyer().forEach(r -> {
             try {
+                if (r.dest() == null || r.dest().isBlank()) {
+                    System.err.println("Rappel ignoré (destinataire vide) pour id=" + r.id());
+                    return;
+                }
                 Mailer.send(cfg, r.dest(), r.sujet(), r.corps());
                 dao.markRappelEnvoyé(r.id());
             } catch (MessagingException ex) {
@@ -73,15 +77,20 @@ public class MainApp extends Application {
 
             try {
                 /* a) mail au prestataire */
-                Mailer.send(cfg, pr.getEmail(),
-                        Mailer.subjToPresta(cfg,v),
-                        Mailer.bodyToPresta(cfg,v));
+                if (pr.getEmail() != null && !pr.getEmail().isBlank()) {
+                    Mailer.send(cfg, pr.getEmail(),
+                            Mailer.subjToPresta(cfg,v),
+                            Mailer.bodyToPresta(cfg,v));
+                } else {
+                    System.err.println("Pré‑avis ignoré (destinataire vide) pour facture=" + f.getId());
+                }
 
                 /* b) mail à nous‑même si renseigné */
-                if (!cfg.copyToSelf().isBlank())
+                if (cfg.copyToSelf() != null && !cfg.copyToSelf().isBlank()) {
                     Mailer.send(cfg, cfg.copyToSelf(),
-                        Mailer.subjToSelf(cfg,v),
-                        Mailer.bodyToSelf(cfg,v));
+                            Mailer.subjToSelf(cfg,v),
+                            Mailer.bodyToSelf(cfg,v));
+                }
 
                 dao.marquerPreavisEnvoye(f.getId());
                 System.out.println("Pré‑avis envoyé pour facture "+f.getId());

--- a/src/main/java/org/example/gui/MailQuickSetupDialog.java
+++ b/src/main/java/org/example/gui/MailQuickSetupDialog.java
@@ -152,7 +152,7 @@ public class MailQuickSetupDialog extends Dialog<MailPrefs> {
             tfHost.setDisable(!classic);
             tfPort.setDisable(!classic);
             cbSSL.setDisable(!classic);
-            tfUser.setDisable(!classic);
+            tfUser.setDisable(false);
             tfPwd.setDisable(!classic);
             cbAuto.setDisable(!classic);
             bOAuth.setVisible(!classic);
@@ -293,6 +293,10 @@ public class MailQuickSetupDialog extends Dialog<MailPrefs> {
             ThemeManager.apply(td);
             td.showAndWait().ifPresent(addr -> {
                 try {
+                    if (addr == null || addr.isBlank()) {
+                        System.err.println("Envoi de test ignoré (destinataire vide)");
+                        return;
+                    }
                     if (rbOauth2.isSelected() && gmailSvc[0] != null) {
                         Session s = gmailSvc[0].createSession(tfGmail.getText());
                         Message m = new MimeMessage(s);

--- a/src/main/java/org/example/gui/MailSettingsDialog.java
+++ b/src/main/java/org/example/gui/MailSettingsDialog.java
@@ -119,6 +119,10 @@ public class MailSettingsDialog extends Dialog<MailPrefs> {
             ThemeManager.apply(td);
             td.showAndWait().ifPresent(addr -> {
                 try {
+                    if (addr == null || addr.isBlank()) {
+                        System.err.println("Envoi de test ignoré (destinataire vide)");
+                        return;
+                    }
                     Mailer.send(tmp, addr, "Test", "Ceci est un message de test.");
                     Alert a = new Alert(Alert.AlertType.INFORMATION, "E-mail envoyé", ButtonType.OK);
                     ThemeManager.apply(a);

--- a/src/main/java/org/example/gui/MainView.java
+++ b/src/main/java/org/example/gui/MainView.java
@@ -599,6 +599,10 @@ public class MainView {
                 MailPrefs cfg = mailPrefsDao.load();     // charger la config
                 if(cbNow.isSelected()){
                     runAsync(() -> {
+                        if (tfDest.getText() == null || tfDest.getText().isBlank()) {
+                            System.err.println("Envoi immédiat ignoré (destinataire vide)");
+                            return null;
+                        }
                         Map<String,String> v = Mailer.vars(pr,f);
                         Mailer.send(cfg,
                                     tfDest.getText(),


### PR DESCRIPTION
## Summary
- fix disabling of `Utilisateur` field in Gmail OAuth setup
- skip sending email if recipient is empty
- ignore empty addresses in test email dialogs

## Testing
- `mvn -q test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68702d36a568832eaa655aeaf0b09f52