### PR TITLE
Improve OAuth service handling in Mailer

### DIFF
--- a/src/main/java/org/example/MainApp.java
+++ b/src/main/java/org/example/MainApp.java
@@ -54,7 +54,7 @@ public class MainApp extends Application {
         // ② rappels manuels (table rappels)
         dao.rappelsÀEnvoyer().forEach(r -> {
             try {
-                Mailer.send(cfg, r.dest(), r.sujet(), r.corps());
+                Mailer.send(mailPrefsDao, cfg, r.dest(), r.sujet(), r.corps());
                 dao.markRappelEnvoyé(r.id());
             } catch (MessagingException ex) {
                 handleAuthException(ex);
@@ -73,13 +73,13 @@ public class MainApp extends Application {
 
             try {
                 /* a) mail au prestataire */
-                Mailer.send(cfg, pr.getEmail(),
+                Mailer.send(mailPrefsDao, cfg, pr.getEmail(),
                         Mailer.subjToPresta(cfg,v),
                         Mailer.bodyToPresta(cfg,v));
 
                 /* b) mail à nous‑même si renseigné */
                 if (!cfg.copyToSelf().isBlank())
-                    Mailer.send(cfg, cfg.copyToSelf(),
+                    Mailer.send(mailPrefsDao, cfg, cfg.copyToSelf(),
                         Mailer.subjToSelf(cfg,v),
                         Mailer.bodyToSelf(cfg,v));
 

--- a/src/main/java/org/example/gui/MailQuickSetupDialog.java
+++ b/src/main/java/org/example/gui/MailQuickSetupDialog.java
@@ -332,7 +332,7 @@ public class MailQuickSetupDialog extends Dialog<MailPrefs> {
                         m.setText("Ceci est un message de test.");
                         Transport.send(m);
                     } else {
-                        Mailer.send(tmp, addr, "Test", "Ceci est un message de test.");
+                        Mailer.send(dao, tmp, addr, "Test", "Ceci est un message de test.");
                     }
                     Alert a = new Alert(Alert.AlertType.INFORMATION, "E-mail envoyé", ButtonType.OK);
                     ThemeManager.apply(a);

--- a/src/main/java/org/example/gui/MailSettingsDialog.java
+++ b/src/main/java/org/example/gui/MailSettingsDialog.java
@@ -17,7 +17,10 @@ import org.example.mail.MailPrefs;
  */
 @Deprecated
 public class MailSettingsDialog extends Dialog<MailPrefs> {
-    public MailSettingsDialog(MailPrefs current) {
+    private final MailPrefsDAO dao;
+
+    public MailSettingsDialog(MailPrefs current, MailPrefsDAO dao) {
+        this.dao = dao;
         setTitle("Paramètres e-mail");
         setResizable(true);
         getDialogPane().setPrefSize(680, 520);
@@ -119,7 +122,7 @@ public class MailSettingsDialog extends Dialog<MailPrefs> {
             ThemeManager.apply(td);
             td.showAndWait().ifPresent(addr -> {
                 try {
-                    Mailer.send(tmp, addr, "Test", "Ceci est un message de test.");
+                    Mailer.send(dao, tmp, addr, "Test", "Ceci est un message de test.");
                     Alert a = new Alert(Alert.AlertType.INFORMATION, "E-mail envoyé", ButtonType.OK);
                     ThemeManager.apply(a);
                     a.showAndWait();
@@ -159,7 +162,7 @@ public class MailSettingsDialog extends Dialog<MailPrefs> {
 
     /** Utility entry point to open the dialog and persist changes. */
     public static void open(Stage owner, MailPrefsDAO dao) {
-        MailSettingsDialog d = new MailSettingsDialog(dao.load());
+        MailSettingsDialog d = new MailSettingsDialog(dao.load(), dao);
         ThemeManager.apply(d);
         d.initOwner(owner);
         d.setHeaderText("Configurer le serveur SMTP, modèles et délai.");

--- a/src/main/java/org/example/gui/MainView.java
+++ b/src/main/java/org/example/gui/MainView.java
@@ -600,7 +600,7 @@ public class MainView {
                 if(cbNow.isSelected()){
                     runAsync(() -> {
                         Map<String,String> v = Mailer.vars(pr,f);
-                        Mailer.send(cfg,
+                        Mailer.send(mailPrefsDao, cfg,
                                     tfDest.getText(),
                                     Mailer.subjToPresta(cfg,v),
                                     taCorps.getText());     // ici on ne ré‑injecte pas, l’user a déjà édité


### PR DESCRIPTION
## Summary
- reuse OAuth service instances in `Mailer` to cache tokens per provider
- persist Gmail tokens by constructing `GoogleAuthService` with `MailPrefsDAO`
- adapt calls across the app to provide `MailPrefsDAO`
- adjust `MailSettingsDialog` to hold a DAO for test sends

## Testing
- `mvn -q test` *(failed: `command not found: mvn`)*

------
https://chatgpt.com/codex/tasks/task_e_6872d04d3f60832e968afca95abefc72