### PR TITLE
Fix refresh token fallback

### DIFF
--- a/src/main/java/org/example/mail/GoogleAuthService.java
+++ b/src/main/java/org/example/mail/GoogleAuthService.java
@@ -81,6 +81,7 @@ public class GoogleAuthService implements OAuthService {
             JsonNode json = mapper.readTree(resp.body());
             accessToken = json.path("access_token").asText(null);
             String refresh = json.path("refresh_token").asText("");
+            if (refresh.isEmpty()) refresh = prefs.oauthRefresh();
             long exp = json.path("expires_in").asLong();
             long expiry = System.currentTimeMillis() / 1000 + exp;
             prefs = updatePrefs(refresh, expiry);
@@ -118,9 +119,11 @@ public class GoogleAuthService implements OAuthService {
             HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
             JsonNode json = mapper.readTree(resp.body());
             accessToken = json.path("access_token").asText(null);
+            String newRefresh = json.path("refresh_token").asText("");
+            if (newRefresh.isEmpty()) newRefresh = prefs.oauthRefresh();
             long exp = json.path("expires_in").asLong();
             long expiry = System.currentTimeMillis() / 1000 + exp;
-            prefs = updatePrefs(refresh, expiry);
+            prefs = updatePrefs(newRefresh, expiry);
             if (dao != null) dao.save(prefs);
         } catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
## Summary
- preserve refresh token if the OAuth response omits it

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872d2139aec832ea8157b2c5882e972