### PR TITLE
Improve OAuth client validation

### DIFF
--- a/src/main/java/org/example/gui/MailQuickSetupDialog.java
+++ b/src/main/java/org/example/gui/MailQuickSetupDialog.java
@@ -114,7 +114,8 @@ public class MailQuickSetupDialog extends Dialog<MailPrefs> {
         bOAuth.getStyleClass().add("accent");
         bOAuth.setVisible(false);
         bOAuth.setOnAction(ev -> {
-            if (!tfClient.getText().contains(":")) {
+            String[] parts = tfClient.getText().split(":", 2);
+            if (parts.length < 2 || parts[0].isBlank() || parts[1].isBlank()) {
                 Alert a = new Alert(Alert.AlertType.ERROR,
                         "Les champs clientId et clientSecret doivent être renseignés",
                         ButtonType.OK);
@@ -268,7 +269,10 @@ public class MailQuickSetupDialog extends Dialog<MailPrefs> {
                 .or(tfUser.textProperty().isEmpty())
                 .or(portInvalid);
         BooleanBinding oauthInvalid = Bindings.createBooleanBinding(
-                () -> !tfClient.getText().contains(":"), tfClient.textProperty());
+                () -> {
+                    String[] p = tfClient.getText().split(":", 2);
+                    return p.length < 2 || p[0].isBlank() || p[1].isBlank();
+                }, tfClient.textProperty());
         BooleanBinding invalid = rbClassic.selectedProperty().and(classicInvalid)
                 .or(tfFrom.textProperty().isEmpty())
                 .or(rbOauth2.selectedProperty().and(oauthInvalid));

--- a/src/main/java/org/example/mail/GoogleAuthService.java
+++ b/src/main/java/org/example/mail/GoogleAuthService.java
@@ -151,14 +151,12 @@ public class GoogleAuthService implements OAuthService {
     }
 
     private static String[] parseClient(String val) {
-        String[] c = val == null ? new String[]{"", ""} : val.split(":", 2);
-        if (c.length < 2) {
-            String[] tmp = new String[2];
-            tmp[0] = c.length > 0 ? c[0] : "";
-            tmp[1] = "";
-            c = tmp;
+        if (val == null) throw new IllegalArgumentException("No OAuth client configured");
+        String[] parts = val.split(":", 2);
+        if (parts.length < 2 || parts[0].isBlank() || parts[1].isBlank()) {
+            throw new IllegalArgumentException("Client ID and secret must be provided");
         }
-        return c;
+        return parts;
     }
 
     private static String enc(String s) {

--- a/src/main/java/org/example/mail/MicrosoftAuthService.java
+++ b/src/main/java/org/example/mail/MicrosoftAuthService.java
@@ -127,14 +127,12 @@ public class MicrosoftAuthService implements OAuthService {
     }
 
     private static String[] parseClient(String val) {
-        String[] c = val == null ? new String[]{"", ""} : val.split(":", 2);
-        if (c.length < 2) {
-            String[] tmp = new String[2];
-            tmp[0] = c.length > 0 ? c[0] : "";
-            tmp[1] = "";
-            c = tmp;
+        if (val == null) throw new IllegalArgumentException("No OAuth client configured");
+        String[] parts = val.split(":", 2);
+        if (parts.length < 2 || parts[0].isBlank() || parts[1].isBlank()) {
+            throw new IllegalArgumentException("Client ID and secret must be provided");
         }
-        return c;
+        return parts;
     }
 
     private static String enc(String s) {


### PR DESCRIPTION
## Summary
- validate OAuth client ID and secret in `parseClient`
- block OAuth button unless both pieces are set
- update validation logic for OAuth fields

## Testing
- `mvn -q -DskipTests=false test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872f0872664832ea5a8f637772891c6