### PR TITLE
Persist GoogleAuth expiry during send

### DIFF
--- a/src/main/java/org/example/mail/GoogleAuthService.java
+++ b/src/main/java/org/example/mail/GoogleAuthService.java
@@ -42,6 +42,21 @@ public class GoogleAuthService implements OAuthService {
         this.prefs = prefs;
     }
 
+    /**
+     * Internal helper used when a previously created service lacked DAO
+     * support but already fetched tokens.
+     */
+    public GoogleAuthService(MailPrefsDAO dao, MailPrefs prefs) {
+        this.dao = dao;
+        this.prefs = prefs;
+    }
+
+    /** Accessor for current OAuth preferences. */
+    public MailPrefs prefs() { return prefs; }
+
+    /** Whether this service can persist updates. */
+    public boolean hasDao() { return dao != null; }
+
     /** Launch interactive OAuth flow in the user's browser and store refresh token. */
     @Override
     public synchronized void interactiveAuth() {

--- a/src/main/java/org/example/mail/Mailer.java
+++ b/src/main/java/org/example/mail/Mailer.java
@@ -89,6 +89,10 @@ public final class Mailer {
                 default -> svc = OAuthServiceFactory.create(cfg);
             }
             if (svc != null) SERVICES.put(provider, svc);
+        } else if ("gmail".equals(provider) && dao != null
+                && svc instanceof GoogleAuthService gs && !gs.hasDao()) {
+            svc = new GoogleAuthService(dao, gs.prefs());
+            SERVICES.put(provider, svc);
         }
 
         if (svc != null) {


### PR DESCRIPTION
## Summary
- add helper constructors and accessors to `GoogleAuthService`
- replace Gmail service if it lacks DAO support

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872f221d170832e97ea963c072a523a