### PR TITLE
Add encryption for stored OAuth tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,8 @@ sur la classe `GoogleAuthService` et permet de
 générer un `refresh_token` permanent puis un `access_token` à la volée pour les
 envois. Sélectionnez **Gmail OAuth2** dans la boîte de configuration rapide et
 cliquez sur *Se connecter à Google* pour autoriser l'application.
+
+Les champs `oauth_client` et `oauth_refresh` sont chiffrés avant
+l'enregistrement en base. La clé symétrique peut être définie via la
+variable d'environnement `TOKEN_KEY` (seuls les 16 octets utilisés). Un
+mot de passe par défaut est appliqué si la variable est absente.

--- a/src/main/java/org/example/mail/MailPrefs.java
+++ b/src/main/java/org/example/mail/MailPrefs.java
@@ -2,6 +2,7 @@ package org.example.mail;
 
 import java.sql.*;
 import java.util.Map;
+import org.example.util.TokenCrypto;
 
 public record MailPrefs(
         String host, int port, boolean ssl,
@@ -88,9 +89,11 @@ public record MailPrefs(
         String provider = rs.getString("provider");
         if(provider == null) provider = "";
         String oauthClient = rs.getString("oauth_client");
-        if(oauthClient == null) oauthClient = "";
+        if (oauthClient == null) oauthClient = "";
+        else oauthClient = TokenCrypto.decrypt(oauthClient);
         String oauthRefresh = rs.getString("oauth_refresh");
-        if(oauthRefresh == null) oauthRefresh = "";
+        if (oauthRefresh == null) oauthRefresh = "";
+        else oauthRefresh = TokenCrypto.decrypt(oauthRefresh);
         long expiry = 0L;
         try {
             expiry = rs.getLong("oauth_expiry");
@@ -128,8 +131,8 @@ public record MailPrefs(
         ps.setString(4, user());
         ps.setString(5, pwd());
         ps.setString(6, provider());
-        ps.setString(7, oauthClient());
-        ps.setString(8, oauthRefresh());
+        ps.setString(7, TokenCrypto.encrypt(oauthClient()));
+        ps.setString(8, TokenCrypto.encrypt(oauthRefresh()));
         ps.setLong(9, oauthExpiry());
         ps.setString(10, from());
         ps.setString(11, copyToSelf() == null ? "" : copyToSelf());

--- a/src/main/java/org/example/util/TokenCrypto.java
+++ b/src/main/java/org/example/util/TokenCrypto.java
@@ -1,0 +1,72 @@
+package org.example.util;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+public class TokenCrypto {
+    private static final byte[] KEY;
+    private static final String ALGO = "AES/GCM/NoPadding";
+
+    static {
+        String env = System.getenv("TOKEN_KEY");
+        byte[] k = env == null ? null : env.getBytes(StandardCharsets.UTF_8);
+        if (k == null || k.length == 0) {
+            k = "ChangeThisKey123".getBytes(StandardCharsets.UTF_8);
+        }
+        if (k.length < 16) {
+            byte[] t = new byte[16];
+            System.arraycopy(k, 0, t, 0, Math.min(k.length, 16));
+            k = t;
+        } else if (k.length > 16) {
+            byte[] t = new byte[16];
+            System.arraycopy(k, 0, t, 0, 16);
+            k = t;
+        }
+        KEY = k;
+    }
+
+    public static String encrypt(String plain) {
+        if (plain == null || plain.isEmpty()) return plain;
+        try {
+            Cipher c = Cipher.getInstance(ALGO);
+            byte[] iv = new byte[12];
+            new SecureRandom().nextBytes(iv);
+            GCMParameterSpec spec = new GCMParameterSpec(128, iv);
+            SecretKey key = new SecretKeySpec(KEY, "AES");
+            c.init(Cipher.ENCRYPT_MODE, key, spec);
+            byte[] enc = c.doFinal(plain.getBytes(StandardCharsets.UTF_8));
+            ByteBuffer bb = ByteBuffer.allocate(iv.length + enc.length);
+            bb.put(iv);
+            bb.put(enc);
+            return Base64.getEncoder().encodeToString(bb.array());
+        } catch (GeneralSecurityException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String decrypt(String encrypted) {
+        if (encrypted == null || encrypted.isEmpty()) return encrypted;
+        try {
+            byte[] all = Base64.getDecoder().decode(encrypted);
+            byte[] iv = new byte[12];
+            byte[] data = new byte[all.length - 12];
+            System.arraycopy(all, 0, iv, 0, 12);
+            System.arraycopy(all, 12, data, 0, data.length);
+            Cipher c = Cipher.getInstance(ALGO);
+            GCMParameterSpec spec = new GCMParameterSpec(128, iv);
+            SecretKey key = new SecretKeySpec(KEY, "AES");
+            c.init(Cipher.DECRYPT_MODE, key, spec);
+            byte[] dec = c.doFinal(data);
+            return new String(dec, StandardCharsets.UTF_8);
+        } catch (GeneralSecurityException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- encrypt `oauth_client` and `oauth_refresh` values using AES before persistence
- decrypt these values when reading from DB
- expose symmetric key through `TOKEN_KEY` environment variable
- document the new behaviour in the README

## Testing
- ❌ `mvn -q test` *(failed: `mvn` not found)*


------
https://chatgpt.com/codex/tasks/task_e_6872f40e8678832e838384f630dc8cd5