### PR TITLE
Add OAuth error handling

### DIFF
--- a/src/main/java/org/example/mail/GoogleAuthService.java
+++ b/src/main/java/org/example/mail/GoogleAuthService.java
@@ -68,9 +68,18 @@ public class GoogleAuthService implements OAuthService {
             CompletableFuture<String> codeFuture = new CompletableFuture<>();
             server.createContext("/oauth", ex -> {
                 String query = ex.getRequestURI().getRawQuery();
-                String resp = "<html><body>You may close this window.</body></html>";
+                String error = extractParam(query, "error");
+                String resp = (error == null)
+                        ? "<html><body>You may close this window.</body></html>"
+                        : "<html><body>Authorization failed: " + error + "</body></html>";
                 ex.sendResponseHeaders(200, resp.length());
                 try (OutputStream os = ex.getResponseBody()) { os.write(resp.getBytes()); }
+                if (error != null) {
+                    if (!codeFuture.isDone()) {
+                        codeFuture.completeExceptionally(new IllegalStateException(error));
+                    }
+                    return;
+                }
                 String code = extractParam(query, "code");
                 String returnedState = extractParam(query, "state");
                 if (code != null && state.equals(returnedState)) {


### PR DESCRIPTION
## Summary
- handle `error` query parameter in OAuth callback

## Testing
- `apt-get update` *(fails: 403 Forbidden)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687450591c80832eafe236e6d88f51d7