### PR TITLE
Improve OAuth loopback server handling

### DIFF
--- a/src/main/java/org/example/gui/MailQuickSetupDialog.java
+++ b/src/main/java/org/example/gui/MailQuickSetupDialog.java
@@ -137,12 +137,14 @@ public class MailQuickSetupDialog extends Dialog<MailPrefs> {
                 );
                 dao.save(tmp);
                 GoogleAuthService svc = new GoogleAuthService(dao);
-                svc.interactiveAuth();
+                int port = svc.interactiveAuth();
                 prefsBox[0] = dao.load();
                 gmailSvc[0] = svc;
                 tfGmail.setText(prefsBox[0].user());
                 tfGmail.setVisible(true);
-                Alert a = new Alert(Alert.AlertType.INFORMATION, "Authentification réussie", ButtonType.OK);
+                Alert a = new Alert(Alert.AlertType.INFORMATION,
+                        "Authentification réussie (port " + port + ")",
+                        ButtonType.OK);
                 ThemeManager.apply(a);
                 a.showAndWait();
             } catch (Exception ex) {

--- a/src/main/java/org/example/gui/MailWizardDialog.java
+++ b/src/main/java/org/example/gui/MailWizardDialog.java
@@ -32,9 +32,11 @@ public class MailWizardDialog extends Dialog<MailPrefs> {
         bLogin.getStyleClass().add("accent");
         bLogin.setOnAction(ev -> {
             try {
-                new GoogleAuthService(dao).interactiveAuth();
+                int port = new GoogleAuthService(dao).interactiveAuth();
                 prefsBox[0] = dao.load();
-                Alert a = new Alert(Alert.AlertType.INFORMATION, "Authentification réussie", ButtonType.OK);
+                Alert a = new Alert(Alert.AlertType.INFORMATION,
+                        "Authentification réussie (port " + port + ")",
+                        ButtonType.OK);
                 ThemeManager.apply(a);
                 a.showAndWait();
             } catch (Exception ex) {

--- a/src/main/java/org/example/mail/OAuthService.java
+++ b/src/main/java/org/example/mail/OAuthService.java
@@ -2,8 +2,12 @@ package org.example.mail;
 
 /** Basic operations for OAuth-based mail providers. */
 public interface OAuthService {
-    /** Launch an interactive flow to obtain user consent. */
-    void interactiveAuth();
+    /**
+     * Launch an interactive flow to obtain user consent.
+     *
+     * @return port used by the local loopback server
+     */
+    int interactiveAuth();
 
     /** Return a valid access token, refreshing if needed. */
     String getAccessToken();


### PR DESCRIPTION
## Summary
- expose chosen loopback port from OAuth services
- fall back to configurable port if ephemeral port fails
- show port information in Gmail setup dialogs

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_687452af5438832ebea45af8ab25f4aa