### PR TITLE
Ensure OAuth server cleanup via try-finally

### DIFF
--- a/src/main/java/org/example/mail/GoogleAuthService.java
+++ b/src/main/java/org/example/mail/GoogleAuthService.java
@@ -118,7 +118,6 @@ public class GoogleAuthService implements OAuthService {
                     "&code_challenge_method=S256";
             Desktop.getDesktop().browse(URI.create(url));
             String code = codeFuture.join();
-            server.stop(0);
 
             HttpRequest req = HttpRequest.newBuilder(URI.create("https://oauth2.googleapis.com/token"))
                     .header("Content-Type", "application/x-www-form-urlencoded")
@@ -140,8 +139,9 @@ public class GoogleAuthService implements OAuthService {
             if (dao != null) dao.save(prefs);
             return port;
         } catch (Exception e) {
-            if (server != null) server.stop(0);
             throw new RuntimeException("Failed to start loopback server on ports 0 and " + fallback, e);
+        } finally {
+            if (server != null) server.stop(0);
         }
     }
 

--- a/src/main/java/org/example/mail/MicrosoftAuthService.java
+++ b/src/main/java/org/example/mail/MicrosoftAuthService.java
@@ -43,8 +43,8 @@ public class MicrosoftAuthService implements OAuthService {
     public synchronized int interactiveAuth() {
         String[] client = parseClient(prefs.oauthClient());
         if (client[0].isEmpty()) throw new IllegalStateException("Missing client id");
+        HttpServer server = null;
         try {
-            HttpServer server;
             try {
                 server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
             } catch (Exception ex) {
@@ -80,7 +80,6 @@ public class MicrosoftAuthService implements OAuthService {
                     "&prompt=consent";
             Desktop.getDesktop().browse(URI.create(url));
             String code = codeFuture.join();
-            server.stop(0);
 
             HttpRequest req = HttpRequest.newBuilder(URI.create("https://login.microsoftonline.com/common/oauth2/v2.0/token"))
                     .header("Content-Type", "application/x-www-form-urlencoded")
@@ -102,6 +101,8 @@ public class MicrosoftAuthService implements OAuthService {
             return port;
         } catch (Exception e) {
             throw new RuntimeException(e);
+        } finally {
+            if (server != null) server.stop(0);
         }
     }
 


### PR DESCRIPTION
## Summary
- guarantee OAuth local servers are stopped in `GoogleAuthService` and `MicrosoftAuthService`

## Testing
- `mvn test` *(fails: `command not found: mvn`)*

------
https://chatgpt.com/codex/tasks/task_e_687526f0b814832ebfc5304286ef90d6