### PR TITLE
Fix Mailer missing import

### DIFF
--- a/src/main/java/org/example/mail/Mailer.java
+++ b/src/main/java/org/example/mail/Mailer.java
@@ -3,6 +3,7 @@ package org.example.mail;
 import jakarta.mail.*;
 import jakarta.mail.internet.*;
 
+import org.example.dao.MailPrefsDAO;
 import org.example.model.Facture;
 import org.example.model.Prestataire;
 


### PR DESCRIPTION
## Summary
- add missing `MailPrefsDAO` import in `Mailer`

## Testing
- `apt-get update` *(fails: 403 Forbidden)*
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687549a9293c832e8364b08961a83b00