### PR TITLE
Improve Gmail OAuth help text

### DIFF
--- a/src/main/java/org/example/gui/MailOAuthHelpDialog.java
+++ b/src/main/java/org/example/gui/MailOAuthHelpDialog.java
@@ -11,41 +11,37 @@ public class MailOAuthHelpDialog extends Dialog<Void> {
     private static final String HELP_TEXT = """
         ### Activer l’envoi via Gmail – pas à pas
 
-        1. **Créer / ouvrir un projet Google Cloud**
-           - Accédez à https://console.cloud.google.com/ et sélectionnez « Créer un projet ».
-           - Donnez‑lui un nom (ex. *Prestataires‑Manager*).
+        1. **Créer ou ouvrir un projet Google Cloud**
+           - Rendez-vous sur https://console.cloud.google.com/ puis « Créer un projet ».
+           - Nommez-le (ex. *Prestataires‑Manager*).
 
-        2. **Activer l’API Gmail**
-           - Menu : **API & Services › Bibliothèque**.
-           - Recherchez « Gmail API », ouvrez la fiche puis **Activer**.
+        2. **Activer l’API Gmail**
+           - Menu : **API & Services › Bibliothèque**.
+           - Cherchez « Gmail API », ouvrez la fiche puis cliquez sur **Activer**.
 
         3. **Configurer l’écran de consentement OAuth**
-           - Menu : **API & Services › Écran de consentement OAuth**.
-           - Type d’utilisateur : **Externe**.
-           - Renseignez : nom de l’application, e‑mail de contact.
-           - Laissez l’application en mode *Test* ; ajoutez votre propre adresse dans « Testeurs ».
+           - Menu : **API & Services › Écran de consentement OAuth**.
+           - Sélectionnez **Externe** comme type d’utilisateur.
+           - Indiquez un nom d’application et un e‑mail de contact.
+           - Laissez l’application en mode *Test* et ajoutez votre adresse dans « Testeurs ».
 
-        4. **Créer les identifiants OAuth « Application de bureau »**
-           - Menu : **API & Services › Identifiants** → **+ Créer des identifiants** → **ID client OAuth**.
-           - Type d’application : **Application de bureau**.
-           - Notez **ID client** et **Secret client**.
+        4. **Créer les identifiants OAuth – Application de bureau**
+           - Menu : **API & Services › Identifiants** → **+ Créer des identifiants** → **ID client OAuth**.
+           - Choisissez **Application de bureau** et notez l’**ID client** ainsi que le **Secret client**.
 
         5. **Renseigner Prestataires‑Manager**
-           - Dans le champ **Client OAuth**, saisissez :  
-             `ID_CLIENT:SECRET_CLIENT`  (un seul « : », aucun espace).
-           - Cliquez **Se connecter à Google**, accordez les permissions.
+           - Dans le champ **Client OAuth**, saisissez : `ID_CLIENT:SECRET_CLIENT` (un seul « : », aucun espace).
+           - Cliquez ensuite sur **Se connecter à Google** et accordez les permissions.
 
         6. **Tester l’envoi**
-           - Utilisez **Tester l’envoi** pour confirmer la configuration.
+           - Utilisez **Tester l’envoi** pour valider la configuration.
 
         ---
-        **Questions fréquentes**
+        #### Questions fréquentes
 
-        | Problème | Solution |
-        |----------|----------|
-        | *Consentement requis* | Ajoutez votre adresse dans les testeurs. |
-        | *invalid_grant* au refresh | Relancez « Se connecter à Google ». |
-        | Mot de passe d’application | Utilisez l’onglet **SMTP classique** (port 465 SSL). |
+        • **Consentement requis** : ajoutez votre adresse dans les testeurs.
+        • **invalid_grant** lors du rafraîchissement : relancez « Se connecter à Google ».
+        • **Mot de passe d’application** : utilisez l’onglet **SMTP classique** (port 465 SSL).
         """;
 
     public MailOAuthHelpDialog() {


### PR DESCRIPTION
## Summary
- rework text in the Gmail OAuth help dialog
- remove table formatting and present the FAQ as bullet points

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68754cafca78832e80d85f130aacd5bc