### PR TITLE
Enforce TOKEN_KEY requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,6 @@ envois. Sélectionnez **Gmail OAuth2** dans la boîte de configuration rapide et
 cliquez sur *Se connecter à Google* pour autoriser l'application.
 
 Les champs `oauth_client` et `oauth_refresh` sont chiffrés avant
-l'enregistrement en base. La clé symétrique peut être définie via la
-variable d'environnement `TOKEN_KEY` (seuls les 16 octets utilisés). Un
-mot de passe par défaut est appliqué si la variable est absente.
+l'enregistrement en base. La clé symétrique doit être définie via la
+variable d'environnement `TOKEN_KEY` (seuls les 16 octets utilisés).
+L'application refuse de démarrer si cette variable est absente.

--- a/src/main/java/org/example/util/TokenCrypto.java
+++ b/src/main/java/org/example/util/TokenCrypto.java
@@ -16,10 +16,11 @@ public class TokenCrypto {
 
     static {
         String env = System.getenv("TOKEN_KEY");
-        byte[] k = env == null ? null : env.getBytes(StandardCharsets.UTF_8);
-        if (k == null || k.length == 0) {
-            k = "ChangeThisKey123".getBytes(StandardCharsets.UTF_8);
+        if (env == null || env.isBlank()) {
+            System.err.println("TOKEN_KEY must be defined to run the application");
+            throw new IllegalStateException("TOKEN_KEY is required");
         }
+        byte[] k = env.getBytes(StandardCharsets.UTF_8);
         if (k.length < 16) {
             byte[] t = new byte[16];
             System.arraycopy(k, 0, t, 0, Math.min(k.length, 16));


### PR DESCRIPTION
## Summary
- abort startup if `TOKEN_KEY` isn't defined in `TokenCrypto`
- update README to document mandatory `TOKEN_KEY`

## Testing
- `apt-get update` *(fails: repository 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68757af031b0832e8570eccff0503abd