### PR TITLE
Add Facture calculations and DAO tests

### DIFF
--- a/src/main/java/org/example/model/Facture.java
+++ b/src/main/java/org/example/model/Facture.java
@@ -61,4 +61,13 @@ public class Facture implements Serializable {
     public String datePaiementFr(){
         return getDatePaiement()==null ? "" : FR.format(getDatePaiement());
     }
+
+    /* ----- calculs ----- */
+    public static BigDecimal calcTva(BigDecimal ht, BigDecimal pct){
+        return ht.multiply(pct).divide(BigDecimal.valueOf(100));
+    }
+
+    public static BigDecimal calcTtc(BigDecimal ht, BigDecimal pct){
+        return ht.add(calcTva(ht,pct));
+    }
 }

--- a/src/test/java/org/example/dao/DBTest.java
+++ b/src/test/java/org/example/dao/DBTest.java
@@ -99,4 +99,26 @@ public class DBTest {
         Prestataire stored = db.list("").get(0);
         assertEquals("", stored.getDateContrat());
     }
+
+    @Test
+    void testFactureAmountsPersist() {
+        Prestataire p = createSample();
+        db.add(p);
+        int pid = db.list("").get(0).getId();
+
+        BigDecimal ht = new BigDecimal("123.45");
+        BigDecimal pct = new BigDecimal("17.5");
+        BigDecimal mtva = Facture.calcTva(ht, pct);
+        BigDecimal ttc = Facture.calcTtc(ht, pct);
+        Facture f = new Facture(0, pid, "Amounts", LocalDate.now(), ht, pct, mtva, ttc, false, null, false);
+        db.addFacture(f);
+
+        List<Facture> all = db.factures(pid, null);
+        assertEquals(1, all.size());
+        Facture stored = all.get(0);
+        assertEquals(ht, stored.getMontantHt());
+        assertEquals(pct, stored.getTvaPct());
+        assertEquals(mtva, stored.getMontantTva());
+        assertEquals(ttc, stored.getMontantTtc());
+    }
 }

--- a/src/test/java/org/example/model/FactureTest.java
+++ b/src/test/java/org/example/model/FactureTest.java
@@ -1,0 +1,20 @@
+package org.example.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class FactureTest {
+    @Test
+    void testCalculeTtc() {
+        BigDecimal ht = new BigDecimal("150.00");
+        BigDecimal pct = new BigDecimal("20");
+        BigDecimal expectedTva = new BigDecimal("30.00");
+        BigDecimal expectedTtc = new BigDecimal("180.00");
+
+        assertEquals(expectedTva, Facture.calcTva(ht, pct));
+        assertEquals(expectedTtc, Facture.calcTtc(ht, pct));
+    }
+}


### PR DESCRIPTION
## Summary
- add calculation helpers in `Facture`
- test TTC and TVA computations
- verify invoice amounts are preserved by the DAO

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68757c2ccc28832e866ce25266f0a93a