### PR TITLE
Fix SQLite schema upgrade

### DIFF
--- a/src/main/java/org/example/dao/DB.java
+++ b/src/main/java/org/example/dao/DB.java
@@ -312,8 +312,8 @@ public class DB implements AutoCloseable, ConnectionProvider {
 
     private static void ensureFactureMoneyColumns(Connection conn) throws SQLException {
         ensureColumn(conn, "factures", "tva_pct", "REAL NOT NULL DEFAULT 20");
-        ensureColumn(conn, "factures", "montant_tva", "REAL NOT NULL");
-        ensureColumn(conn, "factures", "montant_ttc", "REAL NOT NULL");
+        ensureColumn(conn, "factures", "montant_tva", "REAL NOT NULL DEFAULT 0");
+        ensureColumn(conn, "factures", "montant_ttc", "REAL NOT NULL DEFAULT 0");
         ensureColumn(conn, "factures", "devise", "TEXT DEFAULT 'EUR'");
         try (Statement st = conn.createStatement()) {
             st.executeUpdate("UPDATE factures SET tva_pct=20 WHERE tva_pct IS NULL");


### PR DESCRIPTION
## Summary
- fix SQLite upgrade for NOT NULL facture columns to avoid missing defaults

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875803d023c832eb61e66b54d20405c