### PR TITLE
Fix missing javafx-swing for tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,14 @@
             <artifactId>javafx-fxml</artifactId>
             <version>${javafx.version}</version>
         </dependency>
+        <!-- JFXPanel se trouve ici -->
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-swing</artifactId>
+            <version>${javafx.version}</version>
+            <!-- uniquement nécessaire pour les tests -->
+            <scope>test</scope>
+        </dependency>
 
 
         <!-- OpenPDF (fork LGPL d’iText 4) -->


### PR DESCRIPTION
## Summary
- add `javafx-swing` dependency to compile Swing-based tests

## Testing
- `apt-get update` *(fails: repository 403)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68758e6208fc832eac33547262918d4e