### PR TITLE
Fix HttpClient stubs in tests

### DIFF
--- a/src/test/java/org/example/mail/GoogleAuthServiceTest.java
+++ b/src/test/java/org/example/mail/GoogleAuthServiceTest.java
@@ -14,6 +14,9 @@ import java.sql.Connection;
 import java.sql.Statement;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.time.Duration;
+import java.net.CookieHandler;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -113,14 +116,20 @@ public class GoogleAuthServiceTest {
         }
         public Optional<java.net.ProxySelector> proxy() { return delegate.proxy(); }
         public Optional<java.net.Authenticator> authenticator() { return delegate.authenticator(); }
-        public java.net.CookieHandler cookieHandler() { return delegate.cookieHandler().orElse(null); }
-        public java.time.Duration connectTimeout() { return delegate.connectTimeout().orElse(null); }
+        @Override                       // Java 17
+        public Optional<Duration> connectTimeout() {
+            return delegate.connectTimeout();        // on propage tel‑quel
+        }
+
+        @Override
+        public Optional<CookieHandler> cookieHandler() {
+            return delegate.cookieHandler();
+        }
         public java.net.http.HttpClient.Redirect followRedirects() { return delegate.followRedirects(); }
         public javax.net.ssl.SSLContext sslContext() { return delegate.sslContext(); }
         public javax.net.ssl.SSLParameters sslParameters() { return delegate.sslParameters(); }
         public java.net.http.HttpClient.Version version() { return delegate.version(); }
         public java.util.Optional<java.util.concurrent.Executor> executor() { return delegate.executor(); }
-        public java.net.http.HttpClient.Builder newBuilder() { return delegate.newBuilder(); }
         public void close() { delegate.close(); }
     }
 }

--- a/src/test/java/org/example/mail/MicrosoftAuthServiceTest.java
+++ b/src/test/java/org/example/mail/MicrosoftAuthServiceTest.java
@@ -14,6 +14,9 @@ import java.sql.Connection;
 import java.sql.Statement;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.time.Duration;
+import java.net.CookieHandler;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -112,14 +115,20 @@ public class MicrosoftAuthServiceTest {
         }
         public Optional<java.net.ProxySelector> proxy() { return delegate.proxy(); }
         public Optional<java.net.Authenticator> authenticator() { return delegate.authenticator(); }
-        public java.net.CookieHandler cookieHandler() { return delegate.cookieHandler().orElse(null); }
-        public java.time.Duration connectTimeout() { return delegate.connectTimeout().orElse(null); }
+        @Override                       // Java 17
+        public Optional<Duration> connectTimeout() {
+            return delegate.connectTimeout();        // on propage tel‑quel
+        }
+
+        @Override
+        public Optional<CookieHandler> cookieHandler() {
+            return delegate.cookieHandler();
+        }
         public java.net.http.HttpClient.Redirect followRedirects() { return delegate.followRedirects(); }
         public javax.net.ssl.SSLContext sslContext() { return delegate.sslContext(); }
         public javax.net.ssl.SSLParameters sslParameters() { return delegate.sslParameters(); }
         public java.net.http.HttpClient.Version version() { return delegate.version(); }
         public java.util.Optional<java.util.concurrent.Executor> executor() { return delegate.executor(); }
-        public java.net.http.HttpClient.Builder newBuilder() { return delegate.newBuilder(); }
         public void close() { delegate.close(); }
     }
 }


### PR DESCRIPTION
## Summary
- update `GoogleAuthServiceTest` and `MicrosoftAuthServiceTest` imports
- adjust stub methods to match `HttpClient` API
- remove outdated `newBuilder` method

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687593251200832e80c53d1c5ce2d1e5