### PR TITLE
Add SMTP help dialog

### DIFF
--- a/src/main/java/org/example/gui/MailQuickSetupDialog.java
+++ b/src/main/java/org/example/gui/MailQuickSetupDialog.java
@@ -9,6 +9,7 @@ import javafx.scene.layout.GridPane;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import org.example.gui.MailOAuthHelpDialog;
+import org.example.gui.SmtpHelpDialog;
 import org.example.dao.MailPrefsDAO;
 import org.example.mail.GoogleAuthService;
 import org.example.mail.MailPrefs;
@@ -72,7 +73,13 @@ public class MailQuickSetupDialog extends Dialog<MailPrefs> {
         RadioButton rbClassic = new RadioButton("SMTP classique");
         RadioButton rbOauth2 = new RadioButton("Gmail OAuth2");
         Button bHelp = new Button("Aide");
-        bHelp.setOnAction(ev -> new MailOAuthHelpDialog().showAndWait());
+        bHelp.setOnAction(ev -> {
+            if (rbOauth2.isSelected()) {
+                new MailOAuthHelpDialog().showAndWait();
+            } else {
+                new SmtpHelpDialog().showAndWait();
+            }
+        });
         rbClassic.setToggleGroup(tgMode);
         rbOauth2.setToggleGroup(tgMode);
         rbClassic.setSelected(true);

--- a/src/main/java/org/example/gui/SmtpHelpDialog.java
+++ b/src/main/java/org/example/gui/SmtpHelpDialog.java
@@ -1,0 +1,82 @@
+package org.example.gui;
+
+import javafx.scene.control.*;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
+
+/**
+ * Dialogue affichant une aide pas‑à‑pas pour la configuration classique
+ * SMTP (hôte, port, SSL, authentification…).
+ */
+public class SmtpHelpDialog extends Dialog<Void> {
+
+    private static final String HELP_TEXT = """
+        ### Paramétrage SMTP classique – pas à pas
+        
+        1. **Trouver les informations de votre fournisseur**
+           | Fournisseur        | Serveur (host)            | Port SSL (465) | Port STARTTLS (587) |
+           |--------------------|---------------------------|---------------|---------------------|
+           | Gmail (mot de passe d’appli) | `smtp.gmail.com`    | 465           | 587                 |
+           | Outlook / Office365          | `smtp.office365.com`| 465           | 587                 |
+           | Free                         | `smtp.free.fr`      | 465           | —                   |
+           | Orange                       | `smtp.orange.fr`    | 465           | 587                 |
+           | OVH (e‑mail pro)             | `ssl0.ovh.net`      | 465           | 587                 |
+           
+           Si votre fournisseur n’est pas listé : cherchez « SMTP <nom_du_FAI> ».
+
+        2. **SSL vs. STARTTLS**
+           * **SSL (ou SMTPS)** : connexion chiffrée dès l’ouverture (port 465).  
+           * **STARTTLS** : la connexion démarre en clair puis passe en TLS (port 587).
+
+           Choisissez le port correspondant et cochez / décochez la case **SSL**.
+
+        3. **Utilisateur / mot de passe**
+           * Généralement l’adresse e‑mail complète est utilisée comme *utilisateur*.  
+           * Certains services (Gmail, iCloud…) requièrent un **mot de passe d’application** :
+             créez‑le dans le tableau de bord sécurité du fournisseur et copiez‑le ici.
+
+        4. **Adresse expéditeur**
+           Saisissez l’adresse qui doit apparaître dans le champ « From ».  
+           Pour éviter que les messages arrivent dans le spam :  
+           – utilisez la même adresse que celle du compte SMTP ;  
+           – vérifiez que votre domaine publie un enregistrement **SPF** correct.
+
+        5. **Tester l’envoi**
+           Cliquez sur **Tester l’envoi** : vous recevrez un message témoin.  
+           En cas d’erreur :
+           * `Authentication failed` → vérifiez identifiant / mot de passe.  
+           * `Could not connect` → port ou hôte incorrect, pare‑feu bloquant.  
+           * `535 5.7.0 Authentication Required` → activez l’authentification SMTP dans
+             le webmail ou créez un mot de passe d’application.
+        
+        ---
+        #### Glossaire rapide
+        • **SMTP** : protocole standard d’envoi d’e‑mails.  
+        • **SSL / TLS** : chiffrement de la connexion.  
+        • **STARTTLS** : déclenchement du chiffrement après la connexion.  
+        • **SPF / DKIM** : enregistrements DNS prouvant l’authenticité des mails.        
+        """;
+
+    public SmtpHelpDialog() {
+        setTitle("Aide – configuration SMTP classique");
+        getDialogPane().getButtonTypes().add(ButtonType.CLOSE);
+
+        TextArea ta = new TextArea(HELP_TEXT);
+        ta.setEditable(false);
+        ta.setWrapText(true);
+        ta.setPrefColumnCount(80);
+        ta.setPrefRowCount(40);
+
+        // occuper l’espace disponible
+        ta.setMaxWidth(Double.MAX_VALUE);
+        ta.setMaxHeight(Double.MAX_VALUE);
+        VBox.setVgrow(ta, Priority.ALWAYS);
+
+        Region spacer = new Region(); // pour un padding correct avec le thème sombre
+        VBox root = new VBox(ta, spacer);
+        getDialogPane().setContent(root);
+
+        ThemeManager.apply(this);
+    }
+}


### PR DESCRIPTION
## Summary
- add `SmtpHelpDialog` for step-by-step SMTP setup instructions
- show the relevant help (OAuth or SMTP) in MailQuickSetupDialog

## Testing
- `mvn -v` *(fails: command not found)*
- `apt-get update` *(fails: repository access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6876c0759d90832eb4c437bb9610449e