### PR TITLE
Add AuthDB for authentication

### DIFF
--- a/src/main/java/org/example/dao/AuthDB.java
+++ b/src/main/java/org/example/dao/AuthDB.java
@@ -1,0 +1,23 @@
+package org.example.dao;
+
+import java.sql.*;
+
+public final class AuthDB implements AutoCloseable {
+    private final Connection conn;
+    public AuthDB(String path) throws SQLException {
+        conn = DriverManager.getConnection("jdbc:sqlite:" + path);
+        try (Statement st = conn.createStatement()) {
+            st.executeUpdate("""
+              CREATE TABLE IF NOT EXISTS users(
+                  id        INTEGER PRIMARY KEY,
+                  username  TEXT UNIQUE NOT NULL COLLATE NOCASE,
+                  pwd_hash  TEXT NOT NULL,
+                  kdf_salt  BLOB NOT NULL,
+                  kdf_iters INTEGER NOT NULL,
+                  created   TEXT DEFAULT CURRENT_TIMESTAMP
+              )""");
+        }
+    }
+    public Connection c() { return conn; }
+    @Override public void close() { try { conn.close(); } catch (Exception ignore) {} }
+}


### PR DESCRIPTION
## Summary
- implement `AuthDB` to manage an authentication database `auth.db`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876cb4e8374832ea1b23665b93403a7