### PR TITLE
Add SQLCipher UserDB helper

### DIFF
--- a/src/main/java/org/example/dao/UserDB.java
+++ b/src/main/java/org/example/dao/UserDB.java
@@ -1,0 +1,20 @@
+package org.example.dao;
+
+import javax.crypto.SecretKey;
+import java.sql.*;
+import java.util.Properties;
+
+public final class UserDB implements AutoCloseable {
+    private final Connection c;
+
+    public UserDB(String filePath, SecretKey key) throws SQLException {
+        // SQLCipher attend la clé sous forme HEX ASCII
+        String hex = javax.xml.bind.DatatypeConverter.printHexBinary(key.getEncoded());
+        Properties p = new Properties();
+        p.setProperty("key", hex);
+        c = DriverManager.getConnection("jdbc:sqlite:" + filePath, p);
+        // vous pouvez exécuter ici un CREATE TABLE IF NOT EXISTS...
+    }
+    public Connection connection() { return c; }
+    @Override public void close() { try { c.close(); } catch (Exception ignore) {} }
+}


### PR DESCRIPTION
## Summary
- add a `UserDB` utility class for opening a SQLCipher database

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876d00e21bc832eaeb51cf379ede2d0