### PR TITLE
Add password change workflow

### DIFF
--- a/src/main/java/org/example/security/AuthService.java
+++ b/src/main/java/org/example/security/AuthService.java
@@ -1,11 +1,13 @@
 package org.example.security;
 
 import org.example.dao.AuthDB;
+import org.example.dao.UserDB;
 
 import javax.crypto.SecretKey;
 import java.sql.*;
 import java.security.SecureRandom;
 import java.util.Arrays;
+import java.nio.file.Path;
 
 public final class AuthService {
     private final AuthDB store;
@@ -51,6 +53,52 @@ public final class AuthService {
 
             int uid = rs.getInt("id");
             return new Session(uid, k, username);
+        }
+    }
+
+    /** Obtenir le nom d'utilisateur à partir de l'identifiant. */
+    public String getUsername(int userId) throws SQLException {
+        try (PreparedStatement ps = store.c().prepareStatement(
+                "SELECT username FROM users WHERE id=?")) {
+            ps.setInt(1, userId);
+            ResultSet rs = ps.executeQuery();
+            return rs.next() ? rs.getString("username") : null;
+        }
+    }
+
+    /** Changer le mot de passe et rekey la base chiffrée. */
+    public void changePassword(int userId,
+                               char[] oldPwd, char[] newPwd) throws Exception {
+
+        /* 1) vérifier l'ancien */
+        Session sess = login(getUsername(userId), oldPwd);
+        if (sess == null) throw new IllegalArgumentException("Mot de passe incorrect");
+
+        /* 2) dériver nouvelle clé */
+        byte[] newSalt = RNG.generateSeed(16);
+        int newIter    = 180_000;
+        String newHash = CryptoUtils.hashPwd(newPwd);
+        SecretKey newKey = CryptoUtils.deriveKey(newPwd, newSalt, newIter);
+
+        /* 3) rekey SQLCipher */
+        Path dbFile = Path.of(System.getProperty("user.home"), ".prestataires",
+                              sess.username() + ".db");
+        try (UserDB udb = new UserDB(dbFile.toString(), sess.key())) {
+            Statement st = udb.connection().createStatement();
+            String hex = javax.xml.bind.DatatypeConverter
+                    .printHexBinary(newKey.getEncoded());
+            st.execute("PRAGMA rekey = '" + hex + "'");
+        }
+
+        /* 4) maj table users */
+        try (PreparedStatement ps = store.c().prepareStatement("""
+               UPDATE users SET pwd_hash=?,kdf_salt=?,kdf_iters=?
+               WHERE id=?""")) {
+            ps.setString(1, newHash);
+            ps.setBytes (2, newSalt);
+            ps.setInt   (3, newIter);
+            ps.setInt   (4, userId);
+            ps.executeUpdate();
         }
     }
 


### PR DESCRIPTION
## Summary
- implement `changePassword` in `AuthService`
- add helper `getUsername` to fetch username by user id
- support SQLCipher rekey when changing password

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876d55a7c1c832ea4f2a23cb32b6465