### PR TITLE
Update TokenCrypto usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,6 @@ envois. Sélectionnez **Gmail OAuth2** dans la boîte de configuration rapide et
 cliquez sur *Se connecter à Google* pour autoriser l'application.
 
 Les champs `oauth_client` et `oauth_refresh` sont chiffrés avant
-l'enregistrement en base. La clé symétrique doit être définie via la
-variable d'environnement `TOKEN_KEY` (seuls les 16 octets utilisés).
-L'application refuse de démarrer si cette variable est absente.
+l'enregistrement en base. La clé utilisée correspond à celle dérivée du
+mot de passe utilisateur pour l'ouverture de la base chiffrée, aucune
+variable d'environnement n'est désormais nécessaire.

--- a/src/main/java/org/example/MainApp.java
+++ b/src/main/java/org/example/MainApp.java
@@ -49,16 +49,16 @@ public class MainApp extends Application {
                                       sess.username() + ".db");
                     try (UserDB udb = new UserDB(db.toString(), sess.key())) {
                         DB dao = new DB(udb.connection());
-                        launchUI(primaryStage, dao);        // extrait votre code existant
+                        launchUI(primaryStage, dao, sess.key());        // extrait votre code existant
                     }
                 } catch (Exception e) { e.printStackTrace(); }
             });
         } catch (Exception e) { e.printStackTrace(); }
     }
 
-    private void launchUI(Stage primaryStage, DB dao) {
+    private void launchUI(Stage primaryStage, DB dao, javax.crypto.SecretKey key) {
         this.dao = dao;
-        mailPrefsDao = new MailPrefsDAO(dao);
+        mailPrefsDao = new MailPrefsDAO(dao, key);
         view = new MainView(primaryStage, dao, mailPrefsDao);
         primaryStage.setTitle("Gestion des Prestataires");
         Scene sc = new Scene(view.getRoot(), 920, 600);

--- a/src/main/java/org/example/gui/MainView.java
+++ b/src/main/java/org/example/gui/MainView.java
@@ -64,8 +64,8 @@ public class MainView {
      * Convenience constructor used by older code or tests that don't
      * explicitly provide a {@link MailPrefsDAO} instance.
      */
-    public MainView(Stage stage, DB dao) {
-        this(stage, dao, new MailPrefsDAO(dao));
+    public MainView(Stage stage, DB dao, javax.crypto.SecretKey key) {
+        this(stage, dao, new MailPrefsDAO(dao, key));
     }
 
     public Parent getRoot() {

--- a/src/main/java/org/example/mail/MailPrefs.java
+++ b/src/main/java/org/example/mail/MailPrefs.java
@@ -2,6 +2,7 @@ package org.example.mail;
 
 import java.sql.*;
 import java.util.Map;
+import javax.crypto.SecretKey;
 import org.example.util.TokenCrypto;
 
 public record MailPrefs(
@@ -85,15 +86,15 @@ public record MailPrefs(
         );
     }
 
-    public static MailPrefs fromRS(ResultSet rs) throws SQLException {
+    public static MailPrefs fromRS(ResultSet rs, SecretKey key) throws SQLException {
         String provider = rs.getString("provider");
         if(provider == null) provider = "";
         String oauthClient = rs.getString("oauth_client");
         if (oauthClient == null) oauthClient = "";
-        else oauthClient = TokenCrypto.decrypt(oauthClient);
+        else oauthClient = TokenCrypto.decrypt(oauthClient, key);
         String oauthRefresh = rs.getString("oauth_refresh");
         if (oauthRefresh == null) oauthRefresh = "";
-        else oauthRefresh = TokenCrypto.decrypt(oauthRefresh);
+        else oauthRefresh = TokenCrypto.decrypt(oauthRefresh, key);
         long expiry = 0L;
         try {
             expiry = rs.getLong("oauth_expiry");
@@ -124,15 +125,15 @@ public record MailPrefs(
         );
     }
 
-    public void bind(PreparedStatement ps) throws SQLException {
+    public void bind(PreparedStatement ps, SecretKey key) throws SQLException {
         ps.setString(1, host());
         ps.setInt(2, port());
         ps.setInt(3, ssl() ? 1 : 0);
         ps.setString(4, user());
         ps.setString(5, pwd());
         ps.setString(6, provider());
-        ps.setString(7, TokenCrypto.encrypt(oauthClient()));
-        ps.setString(8, TokenCrypto.encrypt(oauthRefresh()));
+        ps.setString(7, TokenCrypto.encrypt(oauthClient(), key));
+        ps.setString(8, TokenCrypto.encrypt(oauthRefresh(), key));
         ps.setLong(9, oauthExpiry());
         ps.setString(10, from());
         ps.setString(11, copyToSelf() == null ? "" : copyToSelf());

--- a/src/main/java/org/example/util/TokenCrypto.java
+++ b/src/main/java/org/example/util/TokenCrypto.java
@@ -1,73 +1,26 @@
 package org.example.util;
 
-import javax.crypto.Cipher;
+import org.example.security.CryptoUtils;
+
 import javax.crypto.SecretKey;
-import javax.crypto.spec.GCMParameterSpec;
-import javax.crypto.spec.SecretKeySpec;
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.security.GeneralSecurityException;
-import java.security.SecureRandom;
-import java.util.Base64;
 
 public class TokenCrypto {
-    private static final byte[] KEY;
-    private static final String ALGO = "AES/GCM/NoPadding";
+    private TokenCrypto() {}
 
-    static {
-        String env = System.getenv("TOKEN_KEY");
-        if (env == null || env.isBlank()) {
-            System.err.println("TOKEN_KEY must be defined to run the application");
-            throw new IllegalStateException("TOKEN_KEY is required");
-        }
-        byte[] k = env.getBytes(StandardCharsets.UTF_8);
-        if (k.length < 16) {
-            byte[] t = new byte[16];
-            System.arraycopy(k, 0, t, 0, Math.min(k.length, 16));
-            k = t;
-        } else if (k.length > 16) {
-            byte[] t = new byte[16];
-            System.arraycopy(k, 0, t, 0, 16);
-            k = t;
-        }
-        KEY = k;
+    public static String encrypt(String plain, SecretKey key) {
+        if (plain == null || plain.isBlank()) return "";
+        try {
+            var blob = CryptoUtils.encrypt(plain.getBytes(StandardCharsets.UTF_8), key);
+            return CryptoUtils.blobToBase64(blob);
+        } catch (Exception e) { throw new RuntimeException(e); }
     }
 
-    public static String encrypt(String plain) {
-        if (plain == null || plain.isEmpty()) return plain;
+    public static String decrypt(String enc, SecretKey key) {
+        if (enc == null || enc.isBlank()) return "";
         try {
-            Cipher c = Cipher.getInstance(ALGO);
-            byte[] iv = new byte[12];
-            new SecureRandom().nextBytes(iv);
-            GCMParameterSpec spec = new GCMParameterSpec(128, iv);
-            SecretKey key = new SecretKeySpec(KEY, "AES");
-            c.init(Cipher.ENCRYPT_MODE, key, spec);
-            byte[] enc = c.doFinal(plain.getBytes(StandardCharsets.UTF_8));
-            ByteBuffer bb = ByteBuffer.allocate(iv.length + enc.length);
-            bb.put(iv);
-            bb.put(enc);
-            return Base64.getEncoder().encodeToString(bb.array());
-        } catch (GeneralSecurityException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public static String decrypt(String encrypted) {
-        if (encrypted == null || encrypted.isEmpty()) return encrypted;
-        try {
-            byte[] all = Base64.getDecoder().decode(encrypted);
-            byte[] iv = new byte[12];
-            byte[] data = new byte[all.length - 12];
-            System.arraycopy(all, 0, iv, 0, 12);
-            System.arraycopy(all, 12, data, 0, data.length);
-            Cipher c = Cipher.getInstance(ALGO);
-            GCMParameterSpec spec = new GCMParameterSpec(128, iv);
-            SecretKey key = new SecretKeySpec(KEY, "AES");
-            c.init(Cipher.DECRYPT_MODE, key, spec);
-            byte[] dec = c.doFinal(data);
-            return new String(dec, StandardCharsets.UTF_8);
-        } catch (GeneralSecurityException e) {
-            throw new RuntimeException(e);
-        }
+            var blob = CryptoUtils.base64ToBlob(enc);
+            return new String(CryptoUtils.decrypt(blob, key), StandardCharsets.UTF_8);
+        } catch (Exception e) { throw new RuntimeException(e); }
     }
 }

--- a/src/test/java/org/example/dao/MailPrefsDAOTest.java
+++ b/src/test/java/org/example/dao/MailPrefsDAOTest.java
@@ -5,12 +5,15 @@ import org.example.mail.SmtpPreset;
 import org.junit.jupiter.api.*;
 
 import java.sql.*;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class MailPrefsDAOTest {
     private String url;
     private MailPrefsDAO dao;
+    private SecretKey key;
 
     @BeforeEach
     void setUp() throws Exception {
@@ -39,7 +42,8 @@ public class MailPrefsDAOTest {
                 )
             """);
         }
-        dao = new MailPrefsDAO(() -> DB.newConnection(url));
+        key = new SecretKeySpec(new byte[16], "AES");
+        dao = new MailPrefsDAO(() -> DB.newConnection(url), key);
     }
 
 

--- a/src/test/java/org/example/gui/MailQuickSetupDialogAutoTest.java
+++ b/src/test/java/org/example/gui/MailQuickSetupDialogAutoTest.java
@@ -7,6 +7,8 @@ import org.example.dao.DB;
 import org.example.mail.MailPrefs;
 import org.example.mail.autodetect.AutoConfigProvider;
 import org.example.mail.autodetect.AutoConfigResult;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.*;
 
 import java.sql.Connection;
@@ -19,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class MailQuickSetupDialogAutoTest {
     private String url;
     private MailPrefsDAO dao;
+    private SecretKey key;
 
     @BeforeAll
     static void initJfx() { new JFXPanel(); }
@@ -53,7 +56,8 @@ public class MailQuickSetupDialogAutoTest {
                 )
             """);
         }
-        dao = new MailPrefsDAO(() -> DB.newConnection(url));
+        key = new SecretKeySpec(new byte[16], "AES");
+        dao = new MailPrefsDAO(() -> DB.newConnection(url), key);
     }
 
 

--- a/src/test/java/org/example/gui/MailQuickSetupDialogTest.java
+++ b/src/test/java/org/example/gui/MailQuickSetupDialogTest.java
@@ -7,6 +7,8 @@ import org.example.dao.MailPrefsDAO;
 import org.example.dao.DB;
 import org.example.mail.MailPrefs;
 import org.junit.jupiter.api.*;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 
 import java.sql.Connection;
 import java.sql.Statement;
@@ -18,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class MailQuickSetupDialogTest {
     private String url;
     private MailPrefsDAO dao;
+    private SecretKey key;
 
     @BeforeAll
     static void initJfx() {
@@ -54,7 +57,8 @@ public class MailQuickSetupDialogTest {
                 )
             """);
         }
-        dao = new MailPrefsDAO(() -> DB.newConnection(url));
+        key = new SecretKeySpec(new byte[16], "AES");
+        dao = new MailPrefsDAO(() -> DB.newConnection(url), key);
     }
 
     @Test

--- a/src/test/java/org/example/mail/GoogleAuthServiceTest.java
+++ b/src/test/java/org/example/mail/GoogleAuthServiceTest.java
@@ -2,6 +2,8 @@ package org.example.mail;
 
 import org.example.dao.MailPrefsDAO;
 import org.example.dao.DB;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.*;
 
 import java.lang.reflect.Field;
@@ -23,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class GoogleAuthServiceTest {
     private String url;
     private MailPrefsDAO dao;
+    private SecretKey key;
 
     @BeforeEach
     void setUp() throws Exception {
@@ -51,7 +54,8 @@ public class GoogleAuthServiceTest {
                 )
             """);
         }
-        dao = new MailPrefsDAO(() -> DB.newConnection(url));
+        key = new SecretKeySpec(new byte[16], "AES");
+        dao = new MailPrefsDAO(() -> DB.newConnection(url), key);
         MailPrefs prefs = new MailPrefs(
                 "smtp.gmail.com", 465, true,
                 "user", "pwd",

--- a/src/test/java/org/example/mail/MicrosoftAuthServiceTest.java
+++ b/src/test/java/org/example/mail/MicrosoftAuthServiceTest.java
@@ -2,6 +2,8 @@ package org.example.mail;
 
 import org.example.dao.MailPrefsDAO;
 import org.example.dao.DB;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.*;
 
 import java.lang.reflect.Field;
@@ -23,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class MicrosoftAuthServiceTest {
     private String url;
     private MailPrefsDAO dao;
+    private SecretKey key;
 
     @BeforeEach
     void setUp() throws Exception {
@@ -51,7 +54,8 @@ public class MicrosoftAuthServiceTest {
                 )
             """);
         }
-        dao = new MailPrefsDAO(() -> DB.newConnection(url));
+        key = new SecretKeySpec(new byte[16], "AES");
+        dao = new MailPrefsDAO(() -> DB.newConnection(url), key);
         MailPrefs prefs = new MailPrefs(
                 "smtp.office365.com", 587, false,
                 "user", "pwd",


### PR DESCRIPTION
## Summary
- switch TokenCrypto to use CryptoUtils with a provided key
- inject SecretKey throughout MailPrefs and MailPrefsDAO
- update UI and app classes to pass encryption key
- adapt unit tests
- document new key usage

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876d852cde8832e8408327bf3ff6867