### PR TITLE
Fix invalid XML comments in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,20 +132,23 @@
             <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
-        <!-- ---------- Crypto & sécurité ---------- -->
+        <!-- =========  Crypto & sécurité  ========= -->
+
         <!-- 1) Hachage fort des mots de passe -->
         <dependency>
             <groupId>de.mkammerer</groupId>
             <artifactId>argon2-jvm</artifactId>
             <version>2.11</version>
         </dependency>
+
         <!-- 2) Variante SQLCipher -->
         <dependency>
             <groupId>io.github.willena</groupId>
             <artifactId>sqlite-jdbc-crypt</artifactId>
             <version>3.45.2.0</version>
         </dependency>
-        <!-- 3) Utilitaires BouncyCastle (facultatif mais pratique pour AES‑GCM 256) -->
+
+        <!-- 3) BouncyCastle (AES‑GCM 256) -->
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>


### PR DESCRIPTION
## Summary
- remove invalid comment syntax from Crypto dependencies

## Testing
- `apt-get update` *(fails: repository not signed)*
- `mvn -q validate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876dca93270832eb565ef6919f1c34a