### PR TITLE
Use HexFormat for SQLCipher key hex

### DIFF
--- a/src/main/java/org/example/dao/UserDB.java
+++ b/src/main/java/org/example/dao/UserDB.java
@@ -3,13 +3,14 @@ package org.example.dao;
 import javax.crypto.SecretKey;
 import java.sql.*;
 import java.util.Properties;
+import java.util.HexFormat;
 
 public final class UserDB implements AutoCloseable {
     private final Connection c;
 
     public UserDB(String filePath, SecretKey key) throws SQLException {
         // SQLCipher attend la clé sous forme HEX ASCII
-        String hex = javax.xml.bind.DatatypeConverter.printHexBinary(key.getEncoded());
+        String hex = HexFormat.of().formatHex(key.getEncoded());
         Properties p = new Properties();
         p.setProperty("key", hex);
         c = DriverManager.getConnection("jdbc:sqlite:" + filePath, p);

--- a/src/main/java/org/example/security/AuthService.java
+++ b/src/main/java/org/example/security/AuthService.java
@@ -8,6 +8,7 @@ import java.sql.*;
 import java.security.SecureRandom;
 import java.util.Arrays;
 import java.nio.file.Path;
+import java.util.HexFormat;
 
 public final class AuthService {
     private final AuthDB store;
@@ -85,8 +86,7 @@ public final class AuthService {
                               sess.username() + ".db");
         try (UserDB udb = new UserDB(dbFile.toString(), sess.key())) {
             Statement st = udb.connection().createStatement();
-            String hex = javax.xml.bind.DatatypeConverter
-                    .printHexBinary(newKey.getEncoded());
+            String hex = HexFormat.of().formatHex(newKey.getEncoded());
             st.execute("PRAGMA rekey = '" + hex + "'");
         }
 


### PR DESCRIPTION
## Summary
- modernize SQLCipher key conversion using HexFormat in `UserDB`
- apply the same update in `AuthService`

## Testing
- `javac src/main/java/org/example/dao/UserDB.java -d build`
- `javac -cp src/main/java src/main/java/org/example/security/AuthService.java -d build` *(fails: cannot find symbol Argon2)*

------
https://chatgpt.com/codex/tasks/task_e_687818a48094832e91eccca16e348470