### PR TITLE
Add setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,27 @@
+# 1. Installer Java 17 et Maven
+apt-get update -qq
+apt-get install -yqq openjdk-17-jdk maven
+
+# 2. Vérifier les installations
+java -version
+javac -version
+mvn -v
+
+# 3. Configurer Maven pour utiliser le proxy Codex
+mkdir -p ~/.m2
+cat > ~/.m2/settings.xml <<'EOF2'
+<settings>
+  <proxies>
+    <proxy>
+      <id>codexProxy</id>
+      <active>true</active>
+      <protocol>http</protocol>
+      <host>proxy</host>
+      <port>8080</port>
+    </proxy>
+  </proxies>
+</settings>
+EOF2
+
+# 4. Charger les dépendances hors ligne
+mvn dependency:go-offline -B


### PR DESCRIPTION
## Summary
- add `setup.sh` for installing Java and Maven, configuring the proxy, and preloading dependencies

## Testing
- `bash -n setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_687819567378832eae5b3efa31d5ef14