### PR TITLE
Fix Maven dependency for SQLite crypt driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,8 +119,9 @@
         <!-- SQLite JDBC crypt : JAR universel incluant toutes les natives -->
         <dependency>
             <groupId>io.github.willena</groupId>
-            <artifactId>sqlite-jdbc-crypt-all</artifactId>
+            <artifactId>sqlite-jdbc-crypt</artifactId>
             <version>3.45.2.0</version>
+            <classifier>all</classifier>
         </dependency>
 
         <!-- Pool JDBC -->


### PR DESCRIPTION
## Summary
- correct the artifact for sqlite-jdbc-crypt with `classifier` `all`

## Testing
- `bash setup.sh` *(fails: repository 403 errors)*
- `mvn -q -DskipTests install` *(fails: `mvn` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687823cf6a9c832eb089b012039765f0