### PR TITLE
Update sqlite-jdbc dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,21 @@ Elle stocke les informations dans une base SQLite locale et propose une interfac
 ## Version de sqlite-jdbc requise
 
 La méthode `setFullSync(boolean)` nécessite la bibliothèque
-`sqlite-jdbc` en version **3.39.4.0** ou supérieure. Assurez-vous qu'aucun
-autre module n'impose une version plus ancienne. Pour vérifier la
-version effectivement utilisée et détecter d'éventuels conflits, lancez :
+`sqlite-jdbc` en version **3.44.0.0** ou supérieure. Depuis cette
+version, la variante « crypt » est incluse directement dans
+`sqlite-jdbc`. Ajoutez la dépendance suivante dans votre `pom.xml` :
+
+```xml
+<dependency>
+    <groupId>io.github.willena</groupId>
+    <artifactId>sqlite-jdbc</artifactId>
+    <version>3.50.1.0</version>
+</dependency>
+```
+
+Assurez-vous qu'aucun autre module n'impose une version plus ancienne.
+Pour vérifier la version effectivement utilisée et détecter d'éventuels
+conflits, lancez :
 
 ```bash
 mvn -q dependency:tree -Dincludes=org.xerial:sqlite-jdbc

--- a/pom.xml
+++ b/pom.xml
@@ -114,14 +114,14 @@
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
             <version>3.45.2.0</version>
+            <scope>provided</scope>
         </dependency>
 
-        <!-- SQLite JDBC crypt : JAR universel incluant toutes les natives -->
+        <!-- SQLite JDBC avec support du chiffrement -->
         <dependency>
             <groupId>io.github.willena</groupId>
-            <artifactId>sqlite-jdbc-crypt</artifactId>
-            <version>3.45.2.0</version>
-            <classifier>all</classifier>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.50.1.0</version>
         </dependency>
 
         <!-- Pool JDBC -->


### PR DESCRIPTION
## Summary
- use io.github.willena:sqlite-jdbc instead of sqlite-jdbc-crypt
- mark xerial driver as provided to avoid duplicates
- document new dependency in README

## Testing
- `bash setup.sh` *(fails: internet disabled)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68782d629fdc832e8ae1a8da4b878115