### PR TITLE
Ajout création utilisateur initial

### DIFF
--- a/src/main/java/org/example/MainApp.java
+++ b/src/main/java/org/example/MainApp.java
@@ -12,6 +12,7 @@ import org.example.dao.DB;
 import org.example.dao.MailPrefsDAO;
 import org.example.dao.UserDB;
 import org.example.gui.LoginDialog;
+import org.example.gui.RegisterDialog;
 import org.example.gui.MainView;
 import org.example.gui.ThemeManager;
 import org.example.mail.Mailer;
@@ -27,6 +28,7 @@ import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.concurrent.*;
+import java.sql.*;
 
 public class MainApp extends Application {
 
@@ -43,6 +45,15 @@ public class MainApp extends Application {
         try (AuthDB authDB = new AuthDB("auth.db")) {
 
             AuthService auth = new AuthService(authDB);
+
+            try (Statement st = authDB.c().createStatement();
+                 ResultSet rs = st.executeQuery("SELECT COUNT(*) FROM users")) {
+                if (rs.next() && rs.getInt(1) == 0) {
+                    RegisterDialog reg = new RegisterDialog(auth);
+                    reg.showAndWait();
+                }
+            }
+
             LoginDialog dlg = new LoginDialog(auth);
 
             dlg.showAndWait().ifPresent(sess -> {

--- a/src/main/java/org/example/gui/RegisterDialog.java
+++ b/src/main/java/org/example/gui/RegisterDialog.java
@@ -1,0 +1,31 @@
+package org.example.gui;
+
+import javafx.scene.control.*;
+import javafx.scene.layout.GridPane;
+import org.example.security.AuthService;
+
+public class RegisterDialog extends Dialog<Boolean> {
+    public RegisterDialog(AuthService auth) {
+        setTitle("Création d'utilisateur");
+        getDialogPane().getButtonTypes().addAll(ButtonType.OK, ButtonType.CANCEL);
+        TextField tfUser = new TextField();
+        tfUser.setPromptText("Nom d'utilisateur");
+        PasswordField pfPwd = new PasswordField();
+        pfPwd.setPromptText("Mot de passe");
+        GridPane gp = new GridPane();
+        gp.addRow(0, new Label("Utilisateur"), tfUser);
+        gp.addRow(1, new Label("Mot de passe"), pfPwd);
+        getDialogPane().setContent(gp);
+        setResultConverter(bt -> {
+            if (bt == ButtonType.OK) {
+                try {
+                    auth.register(tfUser.getText(), pfPwd.getText().toCharArray());
+                    return Boolean.TRUE;
+                } catch (Exception ex) {
+                    new Alert(Alert.AlertType.ERROR, ex.getMessage()).showAndWait();
+                }
+            }
+            return null;
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- ajouter une boîte de dialogue pour créer un utilisateur
- enregistrer ce premier compte avant d'afficher la fenêtre de connexion

## Testing
- `mvn -v` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_6878337baaa8832eba887b1467e53c70