### PR TITLE
Fix user DB creation on launch

### DIFF
--- a/src/main/java/org/example/MainApp.java
+++ b/src/main/java/org/example/MainApp.java
@@ -25,6 +25,7 @@ import jakarta.mail.MessagingException;
 import com.google.api.client.auth.oauth2.TokenResponseException;
 
 import java.nio.file.Path;
+import java.nio.file.Files;
 import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.concurrent.*;
@@ -62,6 +63,8 @@ public class MainApp extends Application {
                             ".prestataires",
                             sess.username() + ".db");
 
+                    Files.createDirectories(dbPath.getParent());
+
                     /* --------- ouverture SQLCipher + DAO -------------- */
                     userDb = new UserDB(dbPath.toString(), sess.key());
                     dao    = new DB(userDb::connection);   // <-- CORRECTION
@@ -69,6 +72,11 @@ public class MainApp extends Application {
 
                 } catch (Exception e) {
                     e.printStackTrace();
+                    Alert a = new Alert(Alert.AlertType.ERROR,
+                                        "Impossible d’ouvrir la base utilisateur :\n" + e.getMessage(),
+                                        ButtonType.OK);
+                    ThemeManager.apply(a);
+                    a.showAndWait();
                 }
             });
 


### PR DESCRIPTION
## Summary
- ensure the per-user database directory exists before opening
- show an alert if database creation fails

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687837259efc832e8992fa6027a9dbe3