### PR TITLE
Fix missing Insets import

### DIFF
--- a/src/main/java/org/example/gui/LoginDialog.java
+++ b/src/main/java/org/example/gui/LoginDialog.java
@@ -5,6 +5,7 @@ import javafx.application.Platform;
 import javafx.scene.Node;
 import javafx.scene.control.*;
 import javafx.scene.layout.*;
+import javafx.geometry.Insets;
 import javafx.util.Duration;
 import org.example.security.AuthService;
 


### PR DESCRIPTION
## Summary
- fix build error in `LoginDialog` by importing `javafx.geometry.Insets`

## Testing
- `apt-get install -y maven` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_687970ae18d0832e874e021b38b6a18f