### PR TITLE
Fix SQLCipher rekey with WAL mode

### DIFF
--- a/src/main/java/org/example/dao/SqlcipherUtil.java
+++ b/src/main/java/org/example/dao/SqlcipherUtil.java
@@ -1,0 +1,40 @@
+package org.example.dao;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public final class SqlcipherUtil {
+
+    private static String hex(byte[] key) {
+        return java.util.HexFormat.of().formatHex(key);
+    }
+
+    public static void disableWalForRekey(Connection c) throws SQLException {
+        try (Statement st = c.createStatement()) {
+            st.execute("PRAGMA wal_checkpoint(TRUNCATE)");
+            st.execute("PRAGMA journal_mode=DELETE");
+            st.execute("PRAGMA locking_mode=EXCLUSIVE");
+            st.execute("PRAGMA busy_timeout=5000");
+        }
+    }
+
+    public static void enableWal(Connection c) throws SQLException {
+        try (Statement st = c.createStatement()) {
+            st.execute("PRAGMA locking_mode=NORMAL");
+            st.execute("PRAGMA journal_mode=WAL");
+            st.execute("PRAGMA busy_timeout=5000");
+            st.execute("PRAGMA foreign_keys=ON");
+        }
+    }
+
+    public static void rekey(Connection c, byte[] newKey, Integer newKdfItersOrNull) throws SQLException {
+        try (Statement st = c.createStatement()) {
+            if (newKdfItersOrNull != null) {
+                st.execute("PRAGMA kdf_iter = " + newKdfItersOrNull);
+            }
+            st.execute("PRAGMA rekey = \"x'" + hex(newKey) + "'\"");
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure SQLCipher rekey works when WAL is active
- add utility to toggle WAL and perform rekey

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb94202a9c832ea52f9aaa0dec12e8