### PR TITLE
feat: add robust UI initialization and logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,13 @@
             <version>12.3.1</version>
         </dependency>
 
-            
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.13</version>
+        </dependency>
+
+
         <!-- SMTP server embeddable pour le mode local -->
         <dependency>
             <groupId>org.subethamail</groupId>
@@ -154,6 +160,16 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>**/*.css</include>
+                    <include>**/*.ttf</include>
+                    <include>**/*.*</include>
+                </includes>
+            </resource>
+        </resources>
         <plugins>
 
             <plugin>

--- a/src/main/java/org/example/MainApp.java
+++ b/src/main/java/org/example/MainApp.java
@@ -23,6 +23,8 @@ import org.example.model.Facture;
 import org.example.model.Prestataire;
 import org.example.model.Rappel;
 import org.example.security.AuthService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.crypto.SecretKey;
 import java.nio.file.Files;
@@ -40,7 +42,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 public final class MainApp extends Application {
-
+    private static final Logger log = LoggerFactory.getLogger(MainApp.class);
     private DB dao;
     private MailPrefsDAO mailPrefsDao;
     private MainView view;
@@ -51,6 +53,10 @@ public final class MainApp extends Application {
 
     @Override
     public void start(Stage stage) {
+        Thread.setDefaultUncaughtExceptionHandler((t, e) -> {
+            e.printStackTrace();
+        });
+        System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "debug");
         try (AuthDB auth = new AuthDB("auth.db")) {
             AuthService sec = new AuthService(auth);
 
@@ -71,6 +77,7 @@ public final class MainApp extends Application {
 
             Path dbFile = Path.of(System.getProperty("user.home"), ".prestataires", session.username() + ".db");
             Files.createDirectories(dbFile.getParent());
+            log.info("DB path = {}", dbFile);
             userDb = new UserDB(dbFile.toString(), session.key());
             dao = new org.example.dao.SecureDB(userDb::connection, session.userId(), session.key());
             launchUI(stage, session.key());
@@ -99,7 +106,11 @@ public final class MainApp extends Application {
         view = new MainView(stage, dao, mailPrefsDao);
         stage.setTitle("Gestion des Prestataires");
         Scene sc = new Scene(view.getRoot(), 920, 600);
-        ThemeManager.apply(sc);
+        if (Boolean.getBoolean("app.safeUi")) {
+            sc.getStylesheets().clear();
+        } else {
+            ThemeManager.apply(sc);
+        }
         stage.setScene(sc);
         stage.show();
 

--- a/src/main/java/org/example/gui/MainView.java
+++ b/src/main/java/org/example/gui/MainView.java
@@ -1,17 +1,23 @@
 package org.example.gui;
 
+import javafx.collections.FXCollections;
 import javafx.geometry.Insets;
+import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuBar;
 import javafx.scene.control.MenuItem;
+import javafx.scene.control.TableView;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
+import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import org.example.dao.DB;
 import org.example.dao.MailPrefsDAO;
+import org.example.model.Prestataire;
 
 public final class MainView {
     private final Stage stage;
@@ -41,10 +47,36 @@ public final class MainView {
         header.getChildren().add(bMail);
 
         root.setTop(new BorderPane(header, menuBar, null, null, null));
+
+        try {
+            Node center = buildCenter(this.dao);
+            if (center == null) throw new IllegalStateException("center=null après buildCenter");
+            root.setCenter(center);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            Label err = new Label("Erreur d'initialisation de l'interface : " + ex.getMessage());
+            err.setStyle("-fx-text-fill: -fx-text-background-color; -fx-font-size: 14px;");
+            VBox fallback = new VBox(10, new Label("Gestion des Prestataires"), err);
+            fallback.setPadding(new Insets(20));
+            root.setCenter(fallback);
+        }
     }
 
     public Parent getRoot() { return root; }
 
     public void shutdownExecutor() { /* no-op placeholder */ }
+
+    private Node buildCenter(DB dao) {
+        TableView<Prestataire> table = new TableView<>();
+        table.setPlaceholder(new Label("Aucun prestataire pour le moment"));
+        table.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
+        try {
+            table.setItems(FXCollections.observableArrayList(dao.list("")));
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            table.setPlaceholder(new Label("Erreur de chargement : " + ex.getMessage()));
+        }
+        return new StackPane(table);
+    }
 }
 


### PR DESCRIPTION
## Summary
- capture uncaught exceptions at startup and add optional safe UI mode
- log DB path on launch and load center view with clear placeholders
- bundle fonts/resources and enable simple SLF4J logging
- clear application stylesheets when safe UI mode is enabled to avoid incorrect static call

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb969f3e94832ea247af86528cd341