### PR TITLE
Clear scene stylesheets in safe UI mode

### DIFF
--- a/src/main/java/org/example/MainApp.java
+++ b/src/main/java/org/example/MainApp.java
@@ -107,7 +107,7 @@ public final class MainApp extends Application {
         stage.setTitle("Gestion des Prestataires");
         Scene sc = new Scene(view.getRoot(), 920, 600);
         if (Boolean.getBoolean("app.safeUi")) {
-            Scene.setUserAgentStylesheet(null);
+            sc.getStylesheets().clear();
         } else {
             ThemeManager.apply(sc);
         }


### PR DESCRIPTION
## Summary
- Remove incorrect static call to Scene.setUserAgentStylesheet
- Clear scene stylesheets when `app.safeUi` flag is enabled to retain Modena defaults

## Testing
- ❌ `mvn -q -e -DskipTests package` (failed: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 ... Network is unreachable)
- ❌ `mvn -q -e -Dapp.safeUi=true javafx:run` (failed: No plugin found for prefix 'javafx')

------
https://chatgpt.com/codex/tasks/task_e_68bb98b463cc832e9f48a5c1dc078163