### PR TITLE
Fix shading collisions and replace placeholder font usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,16 @@
             <groupId>org.subethamail</groupId>
             <artifactId>subethasmtp</artifactId>
             <version>3.1.7</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.mail</groupId>
+                    <artifactId>mail</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>activation</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 
@@ -227,6 +237,18 @@
                         </goals>
                         <configuration>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>module-info.class</exclude>
+                                        <exclude>META-INF/versions/*/module-info.class</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>org.example.MainApp</mainClass>

--- a/src/main/resources/css/dark.css
+++ b/src/main/resources/css/dark.css
@@ -1,10 +1,5 @@
-@font-face {
-    font-family: "Inter";
-    src: url("/fonts/Inter-Regular.ttf");
-}
-
 .root {
-    -fx-font-family: "Inter","Segoe UI",sans-serif;
+    -fx-font-family: "Segoe UI","Roboto","SF Pro Text",sans-serif;
     -fx-font-size: 14px;
     -fx-base: #1d1f21;
     -fx-background: #1d1f21;

--- a/src/main/resources/css/light.css
+++ b/src/main/resources/css/light.css
@@ -1,10 +1,5 @@
-@font-face {
-    font-family: "Inter";
-    src: url("/fonts/Inter-Regular.ttf");
-}
-
 .root {
-    -fx-font-family: "Inter","Segoe UI",sans-serif;
+    -fx-font-family: "Segoe UI","Roboto","SF Pro Text",sans-serif;
     -fx-font-size: 14px;
     -fx-base: #f5f7fb;
     -fx-background: #f5f7fb;

--- a/src/main/resources/fonts/Inter-Regular.ttf
+++ b/src/main/resources/fonts/Inter-Regular.ttf
@@ -1,1 +1,0 @@
-placeholder font


### PR DESCRIPTION
## Summary
- exclude legacy javax.mail and activation transitive dependencies from SubEthaSMTP to avoid class duplication
- filter module-info and signature metadata during shading to silence encapsulation warnings
- remove the placeholder Inter font asset and point both themes to native system fonts

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68db038597a0832e99b785335d398b6c