### PR TITLE
Prevent DbBootstrap from closing shared connection

### DIFF
--- a/src/main/java/org/example/dao/DbBootstrap.java
+++ b/src/main/java/org/example/dao/DbBootstrap.java
@@ -9,7 +9,14 @@ public final class DbBootstrap {
     private DbBootstrap() {}
 
     public static void ensureSchema(DB dao, UserDB userDb) {
-        try (Connection c = userDb.getConnection(); Statement st = c.createStatement()) {
+        Connection c;
+        try {
+            c = userDb.getConnection();
+        } catch (SQLException e) {
+            throw new RuntimeException("Init DB/migrations : " + e.getMessage(), e);
+        }
+
+        try (Statement st = c.createStatement()) {
             log.debug("[DbBootstrap] Ensuring schema and migrations");
             st.execute("PRAGMA foreign_keys=ON");
             st.execute("PRAGMA busy_timeout=5000");


### PR DESCRIPTION
## Summary
- stop DbBootstrap from closing the shared user database connection during schema initialization
- continue running PRAGMA setup and migrations while only closing statements

## Testing
- mvn -q -DskipTests compile
- mvn -q -Dtest=DbBootstrapConnectionTest test

------
https://chatgpt.com/codex/tasks/task_e_68db07e29f70832e80346f23907e6317